### PR TITLE
Remove dependencies on IAM Conidion API in CEL expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Just-In-Time Access uses [IAM conditions](https://cloud.google.com/iam/docs/cond
   adding a special IAM condition:
 
   ```
-  resource.service == 'jitaccess.cloud.google.com'
+  has({}.jitAccessConstraint)
   ```
 
   You can create the binding for a specific project, or for an entire folder. Instead of granting eligible

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/AssetInventoryAdapter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/AssetInventoryAdapter.java
@@ -31,6 +31,7 @@ import com.google.cloud.asset.v1.AssetServiceClient;
 import com.google.cloud.asset.v1.AssetServiceSettings;
 import com.google.cloud.asset.v1.IamPolicyAnalysisQuery;
 import com.google.common.base.Preconditions;
+import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
 import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.AccessException;
@@ -43,6 +44,7 @@ import java.io.IOException;
 @RequestScoped
 public class AssetInventoryAdapter {
   public static final String OAUTH_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+  private static final int ANALYZE_IAM_POLICY_TIMEOUT_SECS = 30;
 
   private final GoogleCredentials credentials;
 
@@ -92,14 +94,15 @@ public class AssetInventoryAdapter {
                       .setOptions(
                           IamPolicyAnalysisQuery.Options.newBuilder()
                               .setExpandResources(expandResources))
-                      // b/217301546
-                      // .setConditionContext(
-                      //     IamPolicyAnalysisQuery.ConditionContext.newBuilder()
-                      //         .setAccessTime(
-                      //             Timestamp.newBuilder()
-                      //                 .setSeconds(System.currentTimeMillis() / 1000))
-                      //         .build())
-              )
+                       .setConditionContext(
+                           IamPolicyAnalysisQuery.ConditionContext.newBuilder()
+                               .setAccessTime(
+                                   Timestamp.newBuilder()
+                                       .setSeconds(System.currentTimeMillis() / 1000))
+                               .build()))
+              .setExecutionTimeout(Duration.newBuilder()
+                  .setSeconds(ANALYZE_IAM_POLICY_TIMEOUT_SECS)
+                  .build())
               .build();
 
       return client.analyzeIamPolicy(request).getMainAnalysis();

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
@@ -196,7 +196,7 @@ public class RuntimeEnvironment {
             getConfigurationOption(
                 "RESOURCE_SCOPE",
                 "projects/" + getConfigurationOption("GOOGLE_CLOUD_PROJECT", null)),
-            getConfigurationOption("SERVICE_NAME", "jitaccess.cloud.google.com"),
+            Boolean.parseBoolean(getConfigurationOption("INCLUDE_INHERITED_BINDINGS", "false")),
             getConfigurationOption("JUSTIFICATION_HINT", "Bug or case number"),
             Pattern.compile(getConfigurationOption("JUSTIFICATION_PATTERN", ".*")),
             Duration.ofMinutes(

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestElevationService.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestElevationService.java
@@ -44,55 +44,53 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class TestElevationService {
-  private static final String ELEVATION_SERVICE_NAME = "test.googleapis.com";
   private static final UserId SAMPLE_USER = new UserId("user-1", "user-1@example.com");
   private static final Pattern JUSTIFICATION_PATTERN = Pattern.compile(".*");
 
   private static final String SAMPLE_ROLE = "roles/resourcemanager.projectIamAdmin";
-  private static final String ELIGIBILITY_CONDITION =
-      "resource.service == \n'" + ELEVATION_SERVICE_NAME + "'";
+  private static final String ELIGIBILITY_CONDITION = "has({}.jitAccessConstraint)";
 
   // ---------------------------------------------------------------------
   // isConditionIndicatorForEligibility.
   // ---------------------------------------------------------------------
 
   @Test
-  public void whenConditionUsesDoubleQuotes_ThenIsConditionIndicatorForEligibilityReturnsTrue() {
+  public void whenConditionHasRedundantWhitespace_ThenIsConditionIndicatorForEligibilityReturnsTrue() {
     var service =
         new ElevationService(
             Mockito.mock(AssetInventoryAdapter.class),
             Mockito.mock(ResourceManagerAdapter.class),
             new ElevationService.Options(
                 "organizations/0",
-                ELEVATION_SERVICE_NAME,
+                true,
                 "hint",
                 JUSTIFICATION_PATTERN,
                 Duration.ofMinutes(1)));
 
     var condition =
         Expr.newBuilder()
-            .setExpression("resource.service==\"" + ELEVATION_SERVICE_NAME + "\"")
+            .setExpression(" \r\n\t has( {  }.jitAccessConstraint \t ) \t \r\n\r")
             .build();
     assertTrue(service.isConditionIndicatorForEligibility(condition));
   }
 
   @Test
   public void
-      whenConditionUsesSingleQuotesAndRedundantWhitespace_ThenIsConditionIndicatorForEligibilityReturnsTrue() {
+      whenConditionUsesWrongCase_ThenIsConditionIndicatorForEligibilityReturnsTrue() {
     var service =
         new ElevationService(
             Mockito.mock(AssetInventoryAdapter.class),
             Mockito.mock(ResourceManagerAdapter.class),
             new ElevationService.Options(
                 "organizations/0",
-                ELEVATION_SERVICE_NAME,
+                true,
                 "hint",
                 JUSTIFICATION_PATTERN,
                 Duration.ofMinutes(1)));
 
     var condition =
         Expr.newBuilder()
-            .setExpression("   resource.service == \n'" + ELEVATION_SERVICE_NAME + "'\n")
+            .setExpression("HAS({}.JitacceSSConstraint)")
             .build();
     assertTrue(service.isConditionIndicatorForEligibility(condition));
   }
@@ -105,7 +103,7 @@ public class TestElevationService {
             Mockito.mock(ResourceManagerAdapter.class),
             new ElevationService.Options(
                 "organizations/0",
-                ELEVATION_SERVICE_NAME,
+                true,
                 "hint",
                 JUSTIFICATION_PATTERN,
                 Duration.ofMinutes(1)));
@@ -132,7 +130,7 @@ public class TestElevationService {
             resourceAdapter,
             new ElevationService.Options(
                 "organizations/0",
-                ELEVATION_SERVICE_NAME,
+                true,
                 "hint",
                 JUSTIFICATION_PATTERN,
                 Duration.ofMinutes(1)));
@@ -168,7 +166,7 @@ public class TestElevationService {
             resourceAdapter,
             new ElevationService.Options(
                 "organizations/0",
-                ELEVATION_SERVICE_NAME,
+                true,
                 "hint",
                 JUSTIFICATION_PATTERN,
                 Duration.ofMinutes(1)));
@@ -219,7 +217,7 @@ public class TestElevationService {
             resourceAdapter,
             new ElevationService.Options(
                 "organizations/0",
-                ELEVATION_SERVICE_NAME,
+                true,
                 "hint",
                 JUSTIFICATION_PATTERN,
                 Duration.ofMinutes(1)));
@@ -275,7 +273,7 @@ public class TestElevationService {
             resourceAdapter,
             new ElevationService.Options(
                 "organizations/0",
-                ELEVATION_SERVICE_NAME,
+                true,
                 "hint",
                 JUSTIFICATION_PATTERN,
                 Duration.ofMinutes(1)));
@@ -398,7 +396,7 @@ public class TestElevationService {
             resourceAdapter,
             new ElevationService.Options(
                 "organizations/0",
-                ELEVATION_SERVICE_NAME,
+                true,
                 "hint",
                 JUSTIFICATION_PATTERN,
                 Duration.ofMinutes(1)));
@@ -462,7 +460,7 @@ public class TestElevationService {
             resourceAdapter,
             new ElevationService.Options(
                 "organizations/0",
-                ELEVATION_SERVICE_NAME,
+                true,
                 "hint",
                 JUSTIFICATION_PATTERN,
                 Duration.ofMinutes(1)));
@@ -546,7 +544,7 @@ public class TestElevationService {
             resourceAdapter,
             new ElevationService.Options(
                 "organizations/0",
-                ELEVATION_SERVICE_NAME,
+                true,
                 "hint",
                 JUSTIFICATION_PATTERN,
                 Duration.ofMinutes(1)));
@@ -602,7 +600,7 @@ public class TestElevationService {
             resourceAdapter,
             new ElevationService.Options(
                 "organizations/0",
-                ELEVATION_SERVICE_NAME,
+                true,
                 "hint",
                 JUSTIFICATION_PATTERN,
                 Duration.ofMinutes(1)));
@@ -661,7 +659,7 @@ public class TestElevationService {
             resourceAdapter,
             new ElevationService.Options(
                 "organizations/0",
-                ELEVATION_SERVICE_NAME,
+                true,
                 "hint",
                 JUSTIFICATION_PATTERN,
                 Duration.ofMinutes(1)));
@@ -737,7 +735,7 @@ public class TestElevationService {
             resourceAdapter,
             new ElevationService.Options(
                 "organizations/0",
-                ELEVATION_SERVICE_NAME,
+                true,
                 "hint",
                 Pattern.compile("^\\d+$"),
                 Duration.ofMinutes(1)));


### PR DESCRIPTION
* Use condition

  has({}.jitAccessConstraint)

  to mark eligibility. This condition satisfies linting rules
  and avoids relying on any IAM Condition APIs (which might
  change in the futture).

* Ignore inherited bindings by default

  In larger organizations, including inherited bindings
  causes excessive fan-out and results to be clipped.

Change-Id: Ic7925a4905958e40d404a1da54426fb6c0c4e83f