### PR TITLE
b/245024166 Migrate from gRPC to REST

### DIFF
--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -42,13 +42,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>25.1.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -64,22 +57,21 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>1.10.0</version>
     </dependency>
     <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client</artifactId>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-cloudresourcemanager</artifactId>
+      <version>v3-rev20220828-2.0.0</version>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-resourcemanager</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-asset</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-logging</artifactId>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-cloudasset</artifactId>
+      <version>v1-rev20220826-2.0.0</version>
+    </dependency><dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-logging</artifactId>
+      <version>v2-rev20220819-2.0.0</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/AssetInventoryAdapter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/AssetInventoryAdapter.java
@@ -21,9 +21,7 @@
 
 package com.google.solutions.jitaccess.core.adapters;
 
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.cloudasset.v1.CloudAsset;
 import com.google.api.services.cloudasset.v1.model.IamPolicyAnalysis;
@@ -55,7 +53,7 @@ public class AssetInventoryAdapter {
     this.credentials = credentials;
   }
 
-  private CloudAsset createService() throws IOException
+  private CloudAsset createClient() throws IOException
   {
     try {
       return new CloudAsset
@@ -92,7 +90,7 @@ public class AssetInventoryAdapter {
         || scope.startsWith("projects/"));
 
     try {
-      return createService().v1()
+      return createClient().v1()
         .analyzeIamPolicy(scope)
         .setAnalysisQueryIdentitySelectorIdentity("user:" + user.getEmail())
         .setAnalysisQueryOptionsExpandResources(expandResources)

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/AssetInventoryAdapter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/AssetInventoryAdapter.java
@@ -96,8 +96,7 @@ public class AssetInventoryAdapter {
         .analyzeIamPolicy(scope)
         .setAnalysisQueryIdentitySelectorIdentity("user:" + user.getEmail())
         .setAnalysisQueryOptionsExpandResources(expandResources)
-        .setAnalysisQueryConditionContextAccessTime(
-          DateTimeFormatter.ISO_INSTANT.format(Instant.now()))
+        .setAnalysisQueryConditionContextAccessTime(DateTimeFormatter.ISO_INSTANT.format(Instant.now()))
         .setExecutionTimeout(String.format("%ds", ANALYZE_IAM_POLICY_TIMEOUT_SECS))
         .execute()
         .getMainAnalysis();

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/HttpTransport.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/HttpTransport.java
@@ -1,0 +1,58 @@
+//
+// Copyright 2021 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.google.solutions.jitaccess.core.adapters;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+
+public class HttpTransport {
+  public static NetHttpTransport newTransport() throws GeneralSecurityException, IOException {
+    var trustStore = System.getProperty("javax.net.ssl.trustStore");
+    var trustStorePassword = System.getProperty("javax.net.ssl.trustStorePassword");
+
+    if (trustStore != null && trustStorePassword != null) {
+      //
+      // Use a custom keystore.
+      //
+      try (var trustStoreStream = new FileInputStream(trustStore)) {
+        var keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(trustStoreStream, trustStorePassword.toCharArray());
+
+        return new NetHttpTransport
+          .Builder()
+          .trustCertificates(keyStore)
+          .build();
+      }
+    }
+    else {
+      //
+      // Use the Google keystore.
+      //
+      return GoogleNetHttpTransport.newTrustedTransport();
+    }
+  }
+}

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/ResourceManagerAdapter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/ResourceManagerAdapter.java
@@ -21,25 +21,24 @@
 
 package com.google.solutions.jitaccess.core.adapters;
 
-import com.google.api.gax.core.FixedCredentialsProvider;
-import com.google.api.gax.rpc.AbortedException;
-import com.google.api.gax.rpc.FixedHeaderProvider;
-import com.google.api.gax.rpc.PermissionDeniedException;
-import com.google.api.gax.rpc.UnauthenticatedException;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.cloudresourcemanager.v3.CloudResourceManager;
+import com.google.api.services.cloudresourcemanager.v3.model.Binding;
+import com.google.api.services.cloudresourcemanager.v3.model.GetIamPolicyRequest;
+import com.google.api.services.cloudresourcemanager.v3.model.GetPolicyOptions;
+import com.google.api.services.cloudresourcemanager.v3.model.SetIamPolicyRequest;
+import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.resourcemanager.v3.ProjectName;
-import com.google.cloud.resourcemanager.v3.ProjectsClient;
-import com.google.cloud.resourcemanager.v3.ProjectsSettings;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.google.iam.v1.Binding;
-import com.google.iam.v1.GetIamPolicyRequest;
-import com.google.iam.v1.GetPolicyOptions;
-import com.google.iam.v1.SetIamPolicyRequest;
 import com.google.solutions.jitaccess.core.*;
 
 import javax.enterprise.context.RequestScoped;
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.EnumSet;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -58,21 +57,25 @@ public class ResourceManagerAdapter {
     this.credentials = credentials;
   }
 
-  private ProjectsClient createClient(String requestReason) throws IOException {
-    var clientSettings = ProjectsSettings.newBuilder()
-        .setCredentialsProvider(FixedCredentialsProvider.create(this.credentials))
-        .setHeaderProvider(FixedHeaderProvider.create(
-              ImmutableMap.of(
-                  "user-agent", ApplicationVersion.USER_AGENT,
-                  "x-goog-request-reason", requestReason)))
+  private CloudResourceManager createService(String requestReason) throws IOException
+  {
+    try {
+      return new CloudResourceManager
+        .Builder(
+          GoogleNetHttpTransport.newTrustedTransport(),
+          new GsonFactory(),
+          new HttpCredentialsAdapter(GoogleCredentials.getApplicationDefault()))
+        .setApplicationName(ApplicationVersion.USER_AGENT) // TODO: Set "x-goog-request-reason", requestReason
         .build();
-
-    return ProjectsClient.create(clientSettings);
+    }
+    catch (GeneralSecurityException e) {
+      throw new IOException("Creating a ResourceManager client failed", e);
+    }
   }
 
   /** Add an IAM binding using the optimistic concurrency control-mechanism. */
   public void addIamBinding(
-      ProjectName projectId,
+      String projectId,
       Binding binding,
       EnumSet<ResourceManagerAdapter.IamBindingOptions> options,
       String requestReason)
@@ -80,7 +83,9 @@ public class ResourceManagerAdapter {
     Preconditions.checkNotNull(projectId, "projectId");
     Preconditions.checkNotNull(binding, "binding");
 
-    try (var client = createClient(requestReason)) {
+    try {
+      var service = createService(requestReason);
+
       for (int attempt = 0; attempt < MAX_SET_IAM_POLICY_ATTEMPTS; attempt++) {
         //
         // Read current version of policy.
@@ -89,19 +94,17 @@ public class ResourceManagerAdapter {
         // request a v3 policy.
         //
 
-        var request =
-            GetIamPolicyRequest.newBuilder()
-                .setResource(projectId.toString())
-                .setOptions(GetPolicyOptions.newBuilder()
-                        .setRequestedPolicyVersion(3)
-                        .build())
-                .build();
-        var policy = client.getIamPolicy(request).toBuilder();
+        var policy = service
+          .projects()
+          .getIamPolicy(
+            String.format("projects/%s", projectId),
+            new GetIamPolicyRequest()
+              .setOptions(new GetPolicyOptions().setRequestedPolicyVersion(3)))
+          .execute();
+
         policy.setVersion(3);
 
-        if (options.contains(
-            ResourceManagerAdapter.IamBindingOptions
-                .REPLACE_BINDINGS_FOR_SAME_PRINCIPAL_AND_ROLE)) {
+        if (options.contains(ResourceManagerAdapter.IamBindingOptions.REPLACE_BINDINGS_FOR_SAME_PRINCIPAL_AND_ROLE)) {
           //
           // Remove bindings for the same principal and role.
           //
@@ -111,35 +114,36 @@ public class ResourceManagerAdapter {
           //
           Predicate<Binding> isObsolete = b ->
               b.getRole().equals(binding.getRole())
-                  && b.getMembersList().equals(binding.getMembersList())
+                  && b.getMembers().equals(binding.getMembers())
                   && IamConditions.isTemporaryConditionClause(b.getCondition().getExpression());
 
           var nonObsoleteBindings =
-              policy.getBindingsList().stream()
+              policy.getBindings().stream()
                   .filter(isObsolete.negate())
                   .collect(Collectors.toList());
 
-          policy.clearBindings();
-          policy.addAllBindings(nonObsoleteBindings);
+          policy.getBindings().clear();
+          policy.getBindings().addAll(nonObsoleteBindings);
         }
 
         //
         // Apply change and write new version.
         //
-        policy.addBindings(binding);
+        policy.getBindings().add(binding);
 
         try {
-          client.setIamPolicy(
-              SetIamPolicyRequest.newBuilder()
-                  .setResource(projectId.toString())
-                  .setPolicy(policy.build())
-                  .build());
+          service
+            .projects()
+            .setIamPolicy(
+              String.format("projects/%s", projectId),
+              new SetIamPolicyRequest().setPolicy((policy)))
+            .execute();
 
           //
           // Successful update -> quit loop.
           //
           return;
-        } catch (AbortedException e)
+        } catch (GoogleJsonResponseException e) // TODO: Catch 412
         {
           //
           // Concurrent modification - back off and retry.
@@ -153,9 +157,9 @@ public class ResourceManagerAdapter {
 
       throw new AlreadyExistsException(
           "Failed to update IAM bindings due to concurrent modifications");
-    } catch (UnauthenticatedException e) {
+    } catch (GoogleJsonResponseException e) { // TODO Catch 403
       throw new NotAuthenticatedException("Not authenticated", e);
-    } catch (PermissionDeniedException e) {
+    } catch (HttpResponseException e) { // TODO: Catch 404
       throw new AccessDeniedException(String.format("Denied access to project '%s'", projectId), e);
     }
   }

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/services/ElevationService.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/services/ElevationService.java
@@ -109,7 +109,7 @@ public class ElevationService {
     return Stream.ofNullable(analysisResult.getAnalysisResults())
       .flatMap(Collection::stream)
       // Narrow down to IAM bindings with a specific IAM condition.
-      .filter(i -> conditionPredicate.test(i.getIamBinding().getCondition()))
+      .filter(i -> conditionPredicate.test(i.getIamBinding() != null ?i.getIamBinding().getCondition() : null))
       .flatMap(
           i -> i.getAccessControlLists().stream()
               // Narrow down to ACLs with a specific IAM condition evaluation result.

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/services/ElevationService.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/services/ElevationService.java
@@ -109,7 +109,7 @@ public class ElevationService {
     return Stream.ofNullable(analysisResult.getAnalysisResults())
       .flatMap(Collection::stream)
       // Narrow down to IAM bindings with a specific IAM condition.
-      .filter(i -> conditionPredicate.test(i.getIamBinding() != null ?i.getIamBinding().getCondition() : null))
+      .filter(i -> conditionPredicate.test(i.getIamBinding() != null ? i.getIamBinding().getCondition() : null))
       .flatMap(
           i -> i.getAccessControlLists().stream()
               // Narrow down to ACLs with a specific IAM condition evaluation result.
@@ -188,18 +188,18 @@ public class ElevationService {
     //  !activatedRoles.contains(...)
     // because of the different binding statuses.
     //
-    var consolidatedRoles =
-        eligibleRoles.stream()
-            .filter(r -> !activatedRoles.stream()
-                  .anyMatch(a -> a.getFullResourceName().equals(r.getFullResourceName())
-                                 && a.getRole().equals(r.getRole())))
-            .collect(Collectors.toList());
+    var consolidatedRoles = eligibleRoles.stream()
+      .filter(r -> !activatedRoles
+        .stream()
+        .anyMatch(a -> a.getFullResourceName().equals(r.getFullResourceName())
+                       && a.getRole().equals(r.getRole())))
+      .collect(Collectors.toList());
     consolidatedRoles.addAll(activatedRoles);
 
     return new EligibleRoleBindings(
-        consolidatedRoles.stream()
-            .sorted((r1, r2) -> r1.getResourceName().compareTo(r2.getResourceName()))
-            .collect(Collectors.toList()),
+      consolidatedRoles.stream()
+        .sorted((r1, r2) -> r1.getResourceName().compareTo(r2.getResourceName()))
+        .collect(Collectors.toList()),
       Stream.ofNullable(analysisResult.getNonCriticalErrors())
         .flatMap(Collection::stream)
         .map(e -> e.getCause())
@@ -224,14 +224,12 @@ public class ElevationService {
     //
     var eligibleRoles = listEligibleRoleBindings(userId);
     if (!eligibleRoles.getRoleBindings().contains(role)) {
-      throw new AccessDeniedException(
-          String.format("Your user %s is not eligible to activate this role", userId));
+      throw new AccessDeniedException(String.format("Your user %s is not eligible to activate this role", userId));
     }
 
     if (!this.options.getJustificationPattern().matcher(justification).matches()) {
       throw new AccessDeniedException(
-          String.format(
-              "Justification does not meet criteria: %s", this.options.getJustificationHint()));
+          String.format("Justification does not meet criteria: %s", this.options.getJustificationHint()));
     }
 
     //
@@ -249,8 +247,7 @@ public class ElevationService {
       .setCondition(new com.google.api.services.cloudresourcemanager.v3.model.Expr()
         .setTitle(ELEVATION_CONDITION_TITLE)
         .setDescription("User-provided justification: " + justification)
-        .setExpression(IamConditions
-          .createTemporaryConditionClause(elevationStartTime, elevationEndTime)));
+        .setExpression(IamConditions.createTemporaryConditionClause(elevationStartTime, elevationEndTime)));
 
     this.resourceManagerAdapter.addIamBinding(
       role.getResourceName(), // TODO: qualified or unqualified name?

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/services/ElevationService.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/services/ElevationService.java
@@ -166,7 +166,7 @@ public class ElevationService {
         findRoleBindings(
             analysisResult,
             condition -> condition != null && ELEVATION_CONDITION_TITLE.equals(condition.getTitle()),
-            evalResult -> "TRUE".equalsIgnoreCase(evalResult.getEvaluationValue()), // TODO: verify
+            evalResult -> "TRUE".equalsIgnoreCase(evalResult.getEvaluationValue()),
             RoleBinding.RoleBindingStatus.ACTIVATED);
 
     //
@@ -178,7 +178,7 @@ public class ElevationService {
         findRoleBindings(
             analysisResult,
             condition -> condition != null && isConditionIndicatorForEligibility(condition),
-            evalResult -> "CONDITIONAL".equalsIgnoreCase(evalResult.getEvaluationValue()), // TODO: verify
+            evalResult -> "CONDITIONAL".equalsIgnoreCase(evalResult.getEvaluationValue()),
             RoleBinding.RoleBindingStatus.ELIGIBLE);
 
     //
@@ -250,7 +250,7 @@ public class ElevationService {
         .setExpression(IamConditions.createTemporaryConditionClause(elevationStartTime, elevationEndTime)));
 
     this.resourceManagerAdapter.addIamBinding(
-      role.getResourceName(), // TODO: qualified or unqualified name?
+      role.getResourceName(),
       binding,
       EnumSet.of(ResourceManagerAdapter.IamBindingOptions.REPLACE_BINDINGS_FOR_SAME_PRINCIPAL_AND_ROLE),
       justification);

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/IntegrationTestEnvironment.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/IntegrationTestEnvironment.java
@@ -37,7 +37,7 @@ public class IntegrationTestEnvironment {
 
   private static final String SETTINGS_FILE = "test.properties";
   public static final GoogleCredentials INVALID_CREDENTIAL =
-      GoogleCredentials.create(new AccessToken("ey00", new Date()));
+      GoogleCredentials.create(new AccessToken("ey00", new Date(Long.MAX_VALUE)));
 
   public static final String PROJECT_ID;
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/IntegrationTestEnvironment.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/IntegrationTestEnvironment.java
@@ -37,7 +37,12 @@ public class IntegrationTestEnvironment {
 
   private static final String SETTINGS_FILE = "test.properties";
   public static final GoogleCredentials INVALID_CREDENTIAL =
-      GoogleCredentials.create(new AccessToken("ey00", new Date(Long.MAX_VALUE)));
+    new GoogleCredentials(new AccessToken("ey00", new Date(Long.MAX_VALUE)))
+    {
+      @Override
+      public void refresh() {
+      }
+    };
 
   public static final String PROJECT_ID;
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestResourceManagerAdapter.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestResourceManagerAdapter.java
@@ -145,11 +145,11 @@ public class TestResourceManagerAdapter {
 
     assertTrue(
         oldPolicy.getBindings().stream().anyMatch(
-          b -> b.getCondition() != null && b.getCondition().getTitle().equals("old binding")),
+          b -> b.getCondition() != null && "old binding".equals(b.getCondition().getTitle())),
         "old binding has been added");
     assertTrue(
         oldPolicy.getBindings().stream().anyMatch(
-          b -> b.getCondition() != null && b.getCondition().getTitle().equals("permanent binding")));
+          b -> b.getCondition() != null && "permanent binding".equals(b.getCondition().getTitle())));
 
     // Add "new" temporary binding, overriding the old one.
     adapter.addIamBinding(

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestResourceManagerAdapter.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestResourceManagerAdapter.java
@@ -130,7 +130,7 @@ public class TestResourceManagerAdapter {
 
     var service = new CloudResourceManager
       .Builder(
-        GoogleNetHttpTransport.newTrustedTransport(),
+        HttpTransport.newTransport(),
         new GsonFactory(),
         new HttpCredentialsAdapter(GoogleCredentials.getApplicationDefault()))
       .build();
@@ -138,7 +138,7 @@ public class TestResourceManagerAdapter {
     var oldPolicy = service
       .projects()
       .getIamPolicy(
-        IntegrationTestEnvironment.PROJECT_ID,
+        String.format("projects/%s", IntegrationTestEnvironment.PROJECT_ID),
         new GetIamPolicyRequest()
           .setOptions(new GetPolicyOptions().setRequestedPolicyVersion(3)))
       .execute();

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestResourceManagerAdapter.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestResourceManagerAdapter.java
@@ -144,12 +144,12 @@ public class TestResourceManagerAdapter {
       .execute();
 
     assertTrue(
-        oldPolicy.getBindings().stream()
-            .anyMatch(b -> b.getCondition().getTitle().equals("old binding")),
+        oldPolicy.getBindings().stream().anyMatch(
+          b -> b.getCondition() != null && b.getCondition().getTitle().equals("old binding")),
         "old binding has been added");
     assertTrue(
-        oldPolicy.getBindings().stream()
-            .anyMatch(b -> b.getCondition().getTitle().equals("permanent binding")));
+        oldPolicy.getBindings().stream().anyMatch(
+          b -> b.getCondition() != null && b.getCondition().getTitle().equals("permanent binding")));
 
     // Add "new" temporary binding, overriding the old one.
     adapter.addIamBinding(
@@ -168,16 +168,16 @@ public class TestResourceManagerAdapter {
     var newPolicy = service
       .projects()
       .getIamPolicy(
-        IntegrationTestEnvironment.PROJECT_ID,
+        String.format("projects/%s", IntegrationTestEnvironment.PROJECT_ID),
         new GetIamPolicyRequest()
           .setOptions(new GetPolicyOptions().setRequestedPolicyVersion(3)))
       .execute();
 
-    assertFalse(newPolicy.getBindings().stream()
-            .anyMatch(b -> b.getCondition().getTitle().equals("old binding")));
-    assertTrue(newPolicy.getBindings().stream()
-            .anyMatch(b -> b.getCondition().getTitle().equals("new binding")));
-    assertTrue(newPolicy.getBindings().stream()
-            .anyMatch(b -> b.getCondition().getTitle().equals("permanent binding")));
+    assertFalse(newPolicy.getBindings().stream().anyMatch(
+      b -> b.getCondition() != null && b.getCondition().getTitle().equals("old binding")));
+    assertTrue(newPolicy.getBindings().stream().anyMatch(
+      b -> b.getCondition() != null && b.getCondition().getTitle().equals("new binding")));
+    assertTrue(newPolicy.getBindings().stream().anyMatch(
+      b -> b.getCondition() != null && b.getCondition().getTitle().equals("permanent binding")));
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestElevationService.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestElevationService.java
@@ -531,7 +531,7 @@ public class TestElevationService {
             "justification");
 
     assertTrue(expiry.isAfter(OffsetDateTime.now()));
-    assertTrue(expiry.isBefore(OffsetDateTime.now().plusMinutes(1)));
+    assertTrue(expiry.isBefore(OffsetDateTime.now().plusMinutes(2)));
 
     verify(resourceAdapter)
         .addIamBinding(


### PR DESCRIPTION
Use REST instead of gRPC client libraries to:

* Reduce number of dependencies and (~half) size of JAR
* Simplify debugging and request tracing