### PR TITLE
b/260921498 Disable browser caching

### DIFF
--- a/sources/src/main/resources/application.properties
+++ b/sources/src/main/resources/application.properties
@@ -11,7 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+
 # Set the port to the PORT environment variable
 quarkus.http.port=${PORT:8080}
 quarkus.package.type=uber-jar
+
+# Disable banner in logs
 quarkus.banner.enabled=false
+
+# Disable browser caching (most static assets are loaded from a CDN anyway).
+quarkus.http.header."Cache-Control".value=no-cache


### PR DESCRIPTION
Disable caching for all content to avoid presenting stale data, and to prevent issues after applying a version update.

Note that most long-lived content (jquery, etc) is served from a CDN anyway.