### PR TITLE
b/265050744 Strip query strings in Home link

### DIFF
--- a/sources/src/main/resources/META-INF/resources/index.html
+++ b/sources/src/main/resources/META-INF/resources/index.html
@@ -29,7 +29,7 @@
         <header class="mdl-layout__header mdl-layout__header--transparent">
             <div class="mdl-layout__header-row">
                 <!-- Title -->
-                <span class="mdl-layout-title"><a href="javascript:window.location.reload()">Just-in-Time Access</a></span>
+                <span class="mdl-layout-title"><a href="#" id="menu-home">Just-in-Time Access</a></span>
             </div>
         </header>
         <div class="mdl-layout__drawer">
@@ -686,7 +686,8 @@
         const backend = queryParameters.get("debug") ? new DebugModel() : new Model();
         const localSettings = new LocalSettings();
 
-        $("#menu-requestaccess").click(() => window.location.reload());
+        $("#menu-home").click(() => window.location.replace(location.pathname));
+        $("#menu-requestaccess").click(() => window.location.replace(location.pathname));
         $("#menu-help").click(() => gui.helpPane.show());
         $(document).ready(async () => {
             //


### PR DESCRIPTION
Fix Home link when viewing an approval request by stripping the token from the link URL.