### PR TITLE
Handle IAM constraint expressions that are null

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/services/JitConstraints.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/services/JitConstraints.java
@@ -50,6 +50,10 @@ public class JitConstraints {
       return false;
     }
 
+    if (iamCondition.getExpression() == null) {
+      return false;
+    }
+
     // Strip all whitespace to simplify expression matching.
     var expression = iamCondition
       .getExpression()

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestJitConstraints.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestJitConstraints.java
@@ -53,6 +53,12 @@ public class TestJitConstraints {
     assertFalse(JitConstraints.isJitAccessConstraint(null));
   }
 
+  @Test
+  public void whenExpressionIsNull_ThenIsJitAccessConstraintReturnsFalse() {
+    var condition = new Expr().setExpression(null);
+    assertFalse(JitConstraints.isJitAccessConstraint(condition));
+  }
+
   // ---------------------------------------------------------------------
   // isMultiPartyApprovalConstraint.
   // ---------------------------------------------------------------------
@@ -75,5 +81,11 @@ public class TestJitConstraints {
   public void whenConditionIsEmpty_ThenIsMultiPartyApprovalConstraintReturnsFalse() {
     assertFalse(JitConstraints.isMultiPartyApprovalConstraint(new Expr().setExpression("")));
     assertFalse(JitConstraints.isMultiPartyApprovalConstraint(null));
+  }
+
+  @Test
+  public void whenExpressionIsNull_ThenIsMultiPartyApprovalConstraintReturnsFalse() {
+    var condition = new Expr().setExpression(null);
+    assertFalse(JitConstraints.isMultiPartyApprovalConstraint(condition));
   }
 }


### PR DESCRIPTION
It's possible to create IAM constraints that don't have any expressions in them (not saying there's a good reason, but it's definitely possible!). 

I've been running into this as an error when attempting to deploy the app 😅 This patch addresses those cases by failing out similar to unconditional role assignments.