### PR TITLE
b/273390621 Add configuration option for max number of reviewers

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/services/RoleActivationService.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/services/RoleActivationService.java
@@ -284,6 +284,8 @@ public class RoleActivationService {
 
     Preconditions.checkArgument(ProjectId.isProjectFullResourceName(roleBinding.fullResourceName));
     Preconditions.checkArgument(!reviewers.isEmpty(), "At least one reviewer must be provided");
+    Preconditions.checkArgument(reviewers.size() <= this.options.maxNumberOfReviewersPerActivationRequest,
+      "The number of reviewers must not exceed " + this.options.maxNumberOfReviewersPerActivationRequest);
     Preconditions.checkArgument(!reviewers.contains(callerAndBeneficiary), "The beneficiary cannot be a reviewer");
 
     //
@@ -474,14 +476,17 @@ public class RoleActivationService {
     public final Duration activationDuration;
     public final String justificationHint;
     public final Pattern justificationPattern;
+    public final int maxNumberOfReviewersPerActivationRequest;
 
     public Options(
       String justificationHint,
       Pattern justificationPattern,
-      Duration activationDuration) {
+      Duration activationDuration,
+      int maxNumberOfReviewersPerActivationRequest) {
       this.activationDuration = activationDuration;
       this.justificationHint = justificationHint;
       this.justificationPattern = justificationPattern;
+      this.maxNumberOfReviewersPerActivationRequest = maxNumberOfReviewersPerActivationRequest;
     }
   }
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/ApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/ApiResource.java
@@ -377,7 +377,7 @@ public class ApiResource {
       request.role != null && !request.role.isEmpty(),
       "A role is required");
     Preconditions.checkArgument(
-      request.peers != null && request.peers.size() > 0 && request.peers.size() <= 10,
+      request.peers != null && request.peers.size() > 0,
       "At least one peer is required");
     Preconditions.checkArgument(
       request.justification != null && request.justification.length() > 0 && request.justification.length() < 100,

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/ApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/ApiResource.java
@@ -369,6 +369,8 @@ public class ApiResource {
     assert this.activationTokenService != null;
     assert this.notificationService != null;
 
+    var maxReviewers = this.roleActivationService.getOptions().maxNumberOfReviewersPerActivationRequest;
+
     Preconditions.checkArgument(
       projectIdString != null && !projectIdString.trim().isEmpty(),
       "A projectId is required");
@@ -379,6 +381,9 @@ public class ApiResource {
     Preconditions.checkArgument(
       request.peers != null && request.peers.size() > 0,
       "At least one peer is required");
+    Preconditions.checkArgument(
+      request.peers.size() <= maxReviewers,
+      "The number of reviewers must not exceed " + maxReviewers);
     Preconditions.checkArgument(
       request.justification != null && request.justification.length() > 0 && request.justification.length() < 100,
       "A justification must be provided");

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeConfiguration.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeConfiguration.java
@@ -59,6 +59,9 @@ public class RuntimeConfiguration {
     this.justificationHint = new StringSetting(
       List.of("JUSTIFICATION_HINT"),
       "Bug or case number");
+    this.maxNumberOfReviewersPerActivationRequest = new IntSetting(
+      List.of("ACTIVATION_REQUEST_MAX_REVIEWERS"),
+      10);
     
     //
     // Backend service id
@@ -163,6 +166,11 @@ public class RuntimeConfiguration {
    * Backend Service Id for token validation
    */
   public final StringSetting backendServiceId;
+
+  /**
+   * Maximum number of reviewers foa an activation request.
+   */
+  public final IntSetting maxNumberOfReviewersPerActivationRequest;
 
   public boolean isSmtpConfigured() {
     var requiredSettings = List.of(smtpHost, smtpPort, smtpSenderName, smtpSenderAddress);

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
@@ -39,7 +39,6 @@ import com.google.solutions.jitaccess.core.services.ActivationTokenService;
 import com.google.solutions.jitaccess.core.services.NotificationService;
 import com.google.solutions.jitaccess.core.services.RoleActivationService;
 import com.google.solutions.jitaccess.core.services.RoleDiscoveryService;
-import com.google.solutions.jitaccess.web.RuntimeConfiguration.StringSetting;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
@@ -294,7 +293,8 @@ public class RuntimeEnvironment {
     return new RoleActivationService.Options(
       this.configuration.justificationHint.getValue(),
       Pattern.compile(this.configuration.justificationPattern.getValue()),
-      this.configuration.activationTimeout.getValue());
+      this.configuration.activationTimeout.getValue(),
+      this.configuration.maxNumberOfReviewersPerActivationRequest.getValue());
   }
 
   @Produces

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestApiResource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestApiResource.java
@@ -51,6 +51,8 @@ public class TestApiResource {
   private static final UserId SAMPLE_USER_2 = new UserId("user-2@example.com");
 
   private static final String SAMPLE_TOKEN = "eySAMPLE";
+  private static final Pattern DEFAULT_JUSTIFICATION_PATTERN = Pattern.compile("pattern");
+  private static final int DEFAULT_MAX_NUMBER_OF_REVIEWERS = 10;
   private static final ActivationTokenService.TokenWithExpiry SAMPLE_TOKEN_WITH_EXPIRY =
     new ActivationTokenService.TokenWithExpiry(SAMPLE_TOKEN, Instant.now().plusSeconds(10));
 
@@ -92,8 +94,9 @@ public class TestApiResource {
     when(this.resource.roleActivationService.getOptions())
       .thenReturn(new RoleActivationService.Options(
         "hint",
-        Pattern.compile("pattern"),
-        Duration.ofMinutes(5)));
+        DEFAULT_JUSTIFICATION_PATTERN,
+        Duration.ofMinutes(5),
+        DEFAULT_MAX_NUMBER_OF_REVIEWERS));
 
     var response = new RestDispatcher<>(resource, SAMPLE_USER)
       .get("/api/policy", ApiResource.PolicyResponse.class);
@@ -110,8 +113,9 @@ public class TestApiResource {
     when(this.resource.roleActivationService.getOptions())
       .thenReturn(new RoleActivationService.Options(
         "hint",
-        Pattern.compile("pattern"),
-        Duration.ofMinutes(5)));
+        DEFAULT_JUSTIFICATION_PATTERN,
+        Duration.ofMinutes(5),
+        DEFAULT_MAX_NUMBER_OF_REVIEWERS));
 
     var response = new RestDispatcher<>(resource, SAMPLE_USER)
       .get("/api/policy", ApiResource.PolicyResponse.class);


### PR DESCRIPTION
* List default limit of 10 reviewers for an activation request
* Add configuration option ACTIVATION_REQUEST_MAX_REVIEWERS
* Validate number of peers in RoleActivationService
* Validate number of peers in ApiResource and show error message to user if limit exceeded

Cf #51 