### PR TITLE
b/275265215 Extract notification formatting into separate class

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/services/NotificationService.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/services/NotificationService.java
@@ -22,6 +22,7 @@
 package com.google.solutions.jitaccess.core.services;
 
 import com.google.common.base.Preconditions;
+import com.google.common.escape.Escaper;
 import com.google.common.html.HtmlEscapers;
 import com.google.solutions.jitaccess.core.AccessException;
 import com.google.solutions.jitaccess.core.adapters.SmtpAdapter;
@@ -49,6 +50,38 @@ public abstract class NotificationService {
   public abstract void sendNotification(Notification notification) throws NotificationException;
 
   public abstract boolean canSendNotifications();
+
+  /**
+   * Load a message template from a JAR resource.
+   */
+  public static String tryLoadMessageTemplate(String resourceName) throws NotificationException{
+    try (var stream = NotificationService.class
+      .getClassLoader()
+      .getResourceAsStream(resourceName)) {
+
+      if (stream == null) {
+        return null;
+      }
+
+      var content = stream.readAllBytes();
+      if (content.length > 3 &&
+        content[0] == (byte)0xEF &&
+        content[1] == (byte)0xBB &&
+        content[2] == (byte)0xBF) {
+        //
+        // Strip UTF-8 BOM.
+        //
+        return new String(content, 3, content.length - 3);
+      }
+      else {
+        return new String(content);
+      }
+    }
+    catch (IOException e) {
+      throw new NotificationException(
+        String.format("Reading the template %s from the JAR file failed", resourceName), e);
+    }
+  }
 
   // -------------------------------------------------------------------------
   // Inner classes.
@@ -81,12 +114,26 @@ public abstract class NotificationService {
     public void sendNotification(Notification notification) throws NotificationException {
       Preconditions.checkNotNull(notification, "notification");
 
+      var template = tryLoadMessageTemplate(
+        String.format("notifications/%s.html", notification.getTemplateId()));
+      if (template == null) {
+        //
+        // Unknown kind of notification, ignore.
+        //
+        return;
+      }
+
+      var formattedMessage = notification.formatMessage(
+        template,
+        this.options.timeZone,
+        HtmlEscapers.htmlEscaper());
+
       try {
         this.smtpAdapter.sendMail(
           notification.toRecipients,
           notification.ccRecipients,
           notification.subject,
-          notification.formatMessage(this.options.timeZone),
+          formattedMessage,
           notification.isReply()
             ? EnumSet.of(SmtpAdapter.Flags.REPLY)
             : EnumSet.of(SmtpAdapter.Flags.NONE));
@@ -119,7 +166,6 @@ public abstract class NotificationService {
    * Generic notification that can be formatted as a (HTML) email
    */
   public static abstract class Notification {
-    private final String template;
     private final Collection<UserId> toRecipients;
     private final Collection<UserId> ccRecipients;
     private final String subject;
@@ -130,63 +176,36 @@ public abstract class NotificationService {
       return false;
     }
 
+    public abstract String getTemplateId();
+
     protected Notification(
-      String template,
       Collection<UserId> toRecipients,
       Collection<UserId> ccRecipients,
       String subject
     ) {
-      Preconditions.checkNotNull(template, "template");
       Preconditions.checkNotNull(toRecipients, "toRecipients");
       Preconditions.checkNotNull(ccRecipients, "ccRecipients");
       Preconditions.checkNotNull(subject, "subject");
 
-      this.template = template;
       this.toRecipients = toRecipients;
       this.ccRecipients = ccRecipients;
       this.subject = subject;
     }
 
-    /**
-     * Load a message template from a JAR resource.
-     */
-    protected static String loadMessageTemplate(String resourceName) {
-      try (var stream = NotificationService.class
-        .getClassLoader()
-        .getResourceAsStream(resourceName)) {
+    protected String formatMessage(
+      String template,
+      ZoneId zone,
+      Escaper escaper
+      ) {
+      Preconditions.checkNotNull(template, "template");
+      Preconditions.checkNotNull(zone, "zone");
+      Preconditions.checkNotNull(escaper, "escaper");
 
-        if (stream == null) {
-          throw new RuntimeException(
-            String.format("The JAR file does not contain an template named %s", resourceName));
-        }
-
-        var content = stream.readAllBytes();
-        if (content.length > 3 &&
-          content[0] == (byte)0xEF &&
-          content[1] == (byte)0xBB &&
-          content[2] == (byte)0xBF) {
-          //
-          // Strip UTF-8 BOM.
-          //
-          return new String(content, 3, content.length - 3);
-        }
-        else {
-          return new String(content);
-        }
-      }
-      catch (IOException e) {
-        throw new RuntimeException(
-          String.format("Reading the template %s from the JAR file failed", resourceName), e);
-      }
-    }
-
-    protected String formatMessage(ZoneId zone) {
       //
-      // Read email template file from JAR and replace {{PROPERTY}} placeholders.
+      // Replace all {{PROPERTY}} placeholders in the template.
       //
-      var escaper = HtmlEscapers.htmlEscaper();
 
-      var message = this.template;
+      var message = template;
       for (var property : this.properties.entrySet()) {
         String propertyValue;
         if (property.getValue() instanceof Instant) {
@@ -200,7 +219,7 @@ public abstract class NotificationService {
         }
         else {
           //
-          // Convert to a HTML-safe string.
+          // Convert to a safe string.
           //
           propertyValue = escaper.escape(property.getValue().toString());
         }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/ApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/ApiResource.java
@@ -816,7 +816,6 @@ public class ApiResource {
       URL activationRequestUrl) throws MalformedURLException
     {
       super(
-        NotificationService.Notification.loadMessageTemplate("notifications/RequestActivation.html"),
         request.reviewers,
         List.of(request.beneficiary),
         String.format(
@@ -834,6 +833,11 @@ public class ApiResource {
       this.properties.put("BASE_URL", new URL(activationRequestUrl, "/").toString());
       this.properties.put("ACTION_URL", activationRequestUrl.toString());
     }
+
+    @Override
+    public String getTemplateId() {
+      return "RequestActivation";
+    }
   }
 
   /**
@@ -846,7 +850,6 @@ public class ApiResource {
       URL activationRequestUrl) throws MalformedURLException
     {
       super(
-        NotificationService.Notification.loadMessageTemplate("notifications/ActivationApproved.html"),
         List.of(request.beneficiary),
         request.reviewers, // Move reviewers to CC.
         String.format(
@@ -867,6 +870,11 @@ public class ApiResource {
     @Override
     protected boolean isReply() {
       return true;
+    }
+
+    @Override
+    public String getTemplateId() {
+      return "ActivationApproved";
     }
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestNotificationService.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestNotificationService.java
@@ -21,21 +21,16 @@
 
 package com.google.solutions.jitaccess.core.services;
 
-import com.google.common.html.HtmlEscapers;
 import com.google.solutions.jitaccess.core.adapters.SmtpAdapter;
 import com.google.solutions.jitaccess.core.data.UserId;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.time.Instant;
-import java.time.ZoneId;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -115,67 +110,13 @@ public class TestNotificationService {
   }
 
   // -------------------------------------------------------------------------
-  // tryLoadMessageTemplate.
+  // loadResource.
   // -------------------------------------------------------------------------
 
   @Test
-  public void whenTemplateNotFound_ThenTryLoadMessageTemplateReturnsNull() throws Exception
+  public void whenTemplateNotFound_ThenLoadResourceReturnsNull() throws Exception
   {
-    assertNull(NotificationService.tryLoadMessageTemplate("doesnotexist"));
+    assertNull(NotificationService.loadResource("doesnotexist"));
   }
 
-  // -------------------------------------------------------------------------
-  // format.
-  // -------------------------------------------------------------------------
-
-  @Test
-  public void whenPropertiesContainHtmlTags_ThenFormatEscapesTags() {
-    var properties = new HashMap<String, Object>();
-    properties.put("TEST-1", "<value1/>");
-    properties.put("TEST-2", "<value2/>");
-
-    var notification = new TestNotification(
-      new UserId("user@example.com"),
-      "Test email",
-      properties,
-      "ignored-templateid");
-
-    var template = notification.properties
-      .entrySet()
-      .stream()
-      .map(e -> String.format("%s={{%s}}\n", e.getKey(), e.getKey()))
-      .collect(Collectors.joining());
-
-    assertEquals(
-      "TEST-1=&lt;value1/&gt;\nTEST-2=&lt;value2/&gt;\n",
-      notification.formatMessage(
-        template,
-        NotificationService.Options.DEFAULT_TIMEZONE,
-        HtmlEscapers.htmlEscaper()));
-  }
-
-  @Test
-  public void whenPropertiesContainDates_ThenFormatAppliesTimezone() {
-    var properties = new HashMap<String, Object>();
-    properties.put("TEST-1", Instant.ofEpochSecond(86400));
-
-    var notification = new TestNotification(
-      new UserId("user@example.com"),
-      "Test email",
-      properties,
-      "ignored-templateid");
-
-    var template = notification.properties
-      .entrySet()
-      .stream()
-      .map(e -> String.format("%s={{%s}}\n", e.getKey(), e.getKey()))
-      .collect(Collectors.joining());
-
-    assertEquals(
-      "TEST-1=Fri, 2 Jan 1970 10:00:00 +1000",
-      notification.formatMessage(
-        template,
-        ZoneId.of("Australia/Melbourne"),
-        HtmlEscapers.htmlEscaper()).trim());
-  }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestNotificationService.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestNotificationService.java
@@ -21,6 +21,7 @@
 
 package com.google.solutions.jitaccess.core.services;
 
+import com.google.common.html.HtmlEscapers;
 import com.google.solutions.jitaccess.core.adapters.SmtpAdapter;
 import com.google.solutions.jitaccess.core.data.UserId;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -42,21 +44,25 @@ import static org.mockito.Mockito.verify;
 
 public class TestNotificationService {
   private static class TestNotification extends NotificationService.Notification {
+    private final String templateId;
+
     protected TestNotification(
       UserId recipient,
       String subject,
-      Map<String, Object> properties
+      Map<String, Object> properties,
+      String templateId
     ) {
       super(
-        properties
-          .entrySet()
-          .stream()
-          .map(e -> String.format("%s={{%s}}\n", e.getKey(), e.getKey()))
-          .collect(Collectors.joining()),
         List.of(recipient),
         List.of(),
         subject);
       this.properties.putAll(properties);
+      this.templateId = templateId;
+    }
+
+    @Override
+    public String getTemplateId() {
+      return this.templateId;
     }
   }
 
@@ -65,7 +71,7 @@ public class TestNotificationService {
   // -------------------------------------------------------------------------
 
   @Test
-  public void sendNotificationSendsMail() throws Exception {
+  public void whenTemplateNotFound_ThenSendNotificationDoesNotSendMail() throws Exception {
     var mailAdapter = Mockito.mock(SmtpAdapter.class);
     var service = new NotificationService.MailNotificationService(
       mailAdapter,
@@ -75,7 +81,30 @@ public class TestNotificationService {
     service.sendNotification(new TestNotification(
       to,
       "Test email",
-      new HashMap<String, Object>()));
+      new HashMap<String, Object>(),
+      "unknown-templateid"));
+
+    verify(mailAdapter, times(0)).sendMail(
+      eq(List.of(to)),
+      eq(List.of()),
+      eq("Test email"),
+      anyString(),
+      eq(EnumSet.of(SmtpAdapter.Flags.NONE)));
+  }
+
+  @Test
+  public void whenTemplateFound_ThenSendNotificationSendsMail() throws Exception {
+    var mailAdapter = Mockito.mock(SmtpAdapter.class);
+    var service = new NotificationService.MailNotificationService(
+      mailAdapter,
+      new NotificationService.Options(NotificationService.Options.DEFAULT_TIMEZONE));
+
+    var to = new UserId("user@example.com");
+    service.sendNotification(new TestNotification(
+      to,
+      "Test email",
+      new HashMap<String, Object>(),
+      "RequestActivation"));
 
     verify(mailAdapter, times(1)).sendMail(
       eq(List.of(to)),
@@ -83,6 +112,16 @@ public class TestNotificationService {
       eq("Test email"),
       anyString(),
       eq(EnumSet.of(SmtpAdapter.Flags.NONE)));
+  }
+
+  // -------------------------------------------------------------------------
+  // tryLoadMessageTemplate.
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void whenTemplateNotFound_ThenTryLoadMessageTemplateReturnsNull() throws Exception
+  {
+    assertNull(NotificationService.tryLoadMessageTemplate("doesnotexist"));
   }
 
   // -------------------------------------------------------------------------
@@ -98,11 +137,21 @@ public class TestNotificationService {
     var notification = new TestNotification(
       new UserId("user@example.com"),
       "Test email",
-      properties);
+      properties,
+      "ignored-templateid");
+
+    var template = notification.properties
+      .entrySet()
+      .stream()
+      .map(e -> String.format("%s={{%s}}\n", e.getKey(), e.getKey()))
+      .collect(Collectors.joining());
 
     assertEquals(
       "TEST-1=&lt;value1/&gt;\nTEST-2=&lt;value2/&gt;\n",
-      notification.formatMessage(NotificationService.Options.DEFAULT_TIMEZONE));
+      notification.formatMessage(
+        template,
+        NotificationService.Options.DEFAULT_TIMEZONE,
+        HtmlEscapers.htmlEscaper()));
   }
 
   @Test
@@ -113,10 +162,20 @@ public class TestNotificationService {
     var notification = new TestNotification(
       new UserId("user@example.com"),
       "Test email",
-      properties);
+      properties,
+      "ignored-templateid");
+
+    var template = notification.properties
+      .entrySet()
+      .stream()
+      .map(e -> String.format("%s={{%s}}\n", e.getKey(), e.getKey()))
+      .collect(Collectors.joining());
 
     assertEquals(
       "TEST-1=Fri, 2 Jan 1970 10:00:00 +1000",
-      notification.formatMessage(ZoneId.of("Australia/Melbourne")).trim());
+      notification.formatMessage(
+        template,
+        ZoneId.of("Australia/Melbourne"),
+        HtmlEscapers.htmlEscaper()).trim());
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestNotificationTemplate.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestNotificationTemplate.java
@@ -1,0 +1,115 @@
+//
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.google.solutions.jitaccess.core.services;
+
+import com.google.common.html.HtmlEscapers;
+import com.google.solutions.jitaccess.core.data.UserId;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestNotificationTemplate {
+  private static class TestNotification extends NotificationService.Notification {
+    private final String templateId;
+
+    protected TestNotification(
+      UserId recipient,
+      String subject,
+      Map<String, Object> properties,
+      String templateId
+    ) {
+      super(
+        List.of(recipient),
+        List.of(),
+        subject);
+      this.properties.putAll(properties);
+      this.templateId = templateId;
+    }
+
+    @Override
+    public String getTemplateId() {
+      return this.templateId;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // NotificationTemplate.
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void whenPropertiesContainHtmlTags_ThenFormatEscapesTags() {
+    var properties = new HashMap<String, Object>();
+    properties.put("TEST-1", "<value1/>");
+    properties.put("TEST-2", "<value2/>");
+
+    var notification = new TestNotification(
+      new UserId("user@example.com"),
+      "Test email",
+      properties,
+      "ignored-templateid");
+
+    var template = new NotificationService.NotificationTemplate(
+      notification.properties
+        .entrySet()
+        .stream()
+        .map(e -> String.format("%s={{%s}}\n", e.getKey(), e.getKey()))
+        .collect(Collectors.joining()),
+      NotificationService.Options.DEFAULT_TIMEZONE,
+      HtmlEscapers.htmlEscaper());
+
+    assertEquals(
+      "TEST-1=&lt;value1/&gt;\nTEST-2=&lt;value2/&gt;\n",
+      template.format(notification));
+  }
+
+  @Test
+  public void whenPropertiesContainDates_ThenFormatAppliesTimezone() {
+    var properties = new HashMap<String, Object>();
+    properties.put("TEST-1", Instant.ofEpochSecond(86400));
+
+    var notification = new TestNotification(
+      new UserId("user@example.com"),
+      "Test email",
+      properties,
+      "ignored-templateid");
+
+    var template = new NotificationService.NotificationTemplate(
+      notification.properties
+        .entrySet()
+        .stream()
+        .map(e -> String.format("%s={{%s}}\n", e.getKey(), e.getKey()))
+        .collect(Collectors.joining()),
+      ZoneId.of("Australia/Melbourne"),
+      HtmlEscapers.htmlEscaper());
+
+    assertEquals(
+      "TEST-1=Fri, 2 Jan 1970 10:00:00 +1000",
+      template.format(notification).trim());
+  }
+}


### PR DESCRIPTION
Extract formatting logic from `Notification` class into separate classes

* `Notification` objects have a template ID
* Notification service implementations can use this template ID to construct a `NotificationTemplate`
* The `NotificationTemplate` turns the `Notification` object into a piece of formatted text, for example HTML