### PR TITLE
Only emit SMTP warning when configuration is incomplete

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
@@ -114,7 +114,7 @@ public class RuntimeEnvironment {
     //
     var logAdapter = new LogAdapter();
 
-    if (this.configuration.isSmtpConfigured()) {
+    if (!this.configuration.isSmtpConfigured()) {
       logAdapter
         .newWarningEntry(
           LogEvents.RUNTIME_STARTUP,


### PR DESCRIPTION
Fix condition under which the warning is written to the log

Ref #50