### PR TITLE
b/278807834 Force links in email to use HTTPS when deployed on Cloud Run

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
@@ -234,7 +234,7 @@ public class RuntimeEnvironment {
   public UriBuilder createAbsoluteUriBuilder(UriInfo uriInfo) {
     return uriInfo
       .getBaseUriBuilder()
-      .scheme(isRunningOnAppEngine() ? "https" : "http");
+      .scheme(isRunningOnAppEngine() || isRunningOnCloudRun() ? "https" : "http");
   }
 
   public String getProjectId() {


### PR DESCRIPTION
The incoming URL may be HTTP when deployed on Cloud Run. Force the scheme to HTTPS when generating URLs.