### PR TITLE
Google distroless support

### DIFF
--- a/sources/Dockerfile
+++ b/sources/Dockerfile
@@ -34,10 +34,10 @@ RUN mvn package -DskipTests -Dquarkus.package.output-name=jitaccess
 #
 # Package stage.
 #
-FROM openjdk:17
+FROM gcr.io/distroless/java17-debian11
 WORKDIR /app
 
 COPY --from=build /app/target/jitaccess-runner.jar .
 
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/app/jitaccess-runner.jar"]
+CMD ["jitaccess-runner.jar"]


### PR DESCRIPTION
Hello,

Thanks for your work on this project.

Since JIT project has sensitive access to GCP IAM, I'd suggest to migrate from `openjdk:17` base docker image to Google distroless (gcr.io/distroless/java17-debian11) for multiple reasons:

- To reduce possible attack surface
- Less noise and work for auditing image content to reduce the risks for supply chain attack
- reduce image size

We already tested this on our setup and it works as expected and the change is quite simple as you can see.

Let me know if I can help to clarify anything
