### PR TITLE
b/288520591 Remove duplicate warnings by using a set

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/services/Result.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/services/Result.java
@@ -24,6 +24,7 @@ package com.google.solutions.jitaccess.core.services;
 import com.google.common.base.Preconditions;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Result list of T with an optional set of warnings.
@@ -35,11 +36,11 @@ public class Result<T> {
   private final List<T> items;
 
   /**
-   * Non-fatal issues encountered.
+   * Non-fatal issues encountered. Use a set to avoid duplicates.
    */
-  private final List<String> warnings;
+  private final Set<String> warnings;
 
-  public Result(List<T> roleBindings, List<String> warnings) {
+  public Result(List<T> roleBindings, Set<String> warnings) {
     Preconditions.checkNotNull(roleBindings);
 
     this.items = roleBindings;
@@ -50,7 +51,7 @@ public class Result<T> {
     return this.items;
   }
 
-  public List<String> getWarnings() {
+  public Set<String> getWarnings() {
     return warnings;
   }
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/services/RoleDiscoveryService.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/services/RoleDiscoveryService.java
@@ -283,7 +283,7 @@ public class RoleDiscoveryService {
       Stream.ofNullable(analysisResult.getNonCriticalErrors())
         .flatMap(Collection::stream)
         .map(e -> e.getCause())
-        .collect(Collectors.toList()));
+        .collect(Collectors.toSet()));
   }
 
   /**

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/ApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/ApiResource.java
@@ -697,12 +697,12 @@ public class ApiResource {
   }
 
   public static class ProjectRolesResponse {
-    public final List<String> warnings;
+    public final Set<String> warnings;
     public final List<ProjectRole> roles;
 
     private ProjectRolesResponse(
       List<ProjectRole> roleBindings,
-      List<String> warnings
+      Set<String> warnings
     ) {
       Preconditions.checkNotNull(roleBindings, "roleBindings");
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestRoleActivationService.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestRoleActivationService.java
@@ -95,7 +95,7 @@ public class TestRoleActivationService {
             SAMPLE_PROJECT_RESOURCE_1,
             "roles/compute.viewer"), // Different role
           ProjectRole.Status.ELIGIBLE_FOR_JIT)),
-        List.of()));
+        Set.of()));
 
     var service = new RoleActivationService(
       discoveryService,
@@ -175,7 +175,7 @@ public class TestRoleActivationService {
             SAMPLE_PROJECT_RESOURCE_1,
             SAMPLE_ROLE),
           ProjectRole.Status.ELIGIBLE_FOR_JIT)),
-        List.of()));
+        Set.of()));
 
     var service = new RoleActivationService(
       discoveryService,
@@ -286,7 +286,7 @@ public class TestRoleActivationService {
         List.of(new ProjectRole(
           roleBinding,
           ProjectRole.Status.ACTIVATED)),
-        List.of()));
+        Set.of()));
 
     var request = RoleActivationService.ActivationRequest.createForTestingOnly(
       RoleActivationService.ActivationId.newId(RoleActivationService.ActivationType.MPA),
@@ -327,7 +327,7 @@ public class TestRoleActivationService {
         List.of(new ProjectRole(
           roleBinding,
           ProjectRole.Status.ELIGIBLE_FOR_JIT)),
-        List.of()));
+        Set.of()));
 
     var service = new RoleActivationService(
       discoveryService,
@@ -368,11 +368,11 @@ public class TestRoleActivationService {
         List.of(new ProjectRole(
           roleBinding,
           ProjectRole.Status.ELIGIBLE_FOR_MPA)),
-        List.of()));
+        Set.of()));
     when(discoveryService.listEligibleProjectRoles(eq(peer), eq(SAMPLE_PROJECT_ID), any()))
       .thenReturn(new Result<ProjectRole>(
         List.of(),
-        List.of()));
+        Set.of()));
 
     var service = new RoleActivationService(
       discoveryService,
@@ -419,7 +419,7 @@ public class TestRoleActivationService {
         List.of(new ProjectRole(
           roleBinding,
           ProjectRole.Status.ELIGIBLE_FOR_MPA)),
-        List.of()));
+        Set.of()));
     when(discoveryService.listEligibleProjectRoles(
         eq(peer),
         eq(SAMPLE_PROJECT_ID),
@@ -430,7 +430,7 @@ public class TestRoleActivationService {
         List.of(new ProjectRole(
           roleBinding,
           ProjectRole.Status.ELIGIBLE_FOR_MPA)),
-        List.of()));
+        Set.of()));
 
     var service = new RoleActivationService(
       discoveryService,
@@ -490,13 +490,13 @@ public class TestRoleActivationService {
         List.of(new ProjectRole(
           roleBinding,
           ProjectRole.Status.ELIGIBLE_FOR_MPA)),
-        List.of()));
+        Set.of()));
     when(discoveryService.listEligibleProjectRoles(eq(peer), eq(SAMPLE_PROJECT_ID), any()))
       .thenReturn(new Result<ProjectRole>(
         List.of(new ProjectRole(
           roleBinding,
           ProjectRole.Status.ACTIVATED)), // Pretend someone else approved already
-        List.of()));
+        Set.of()));
 
     var service = new RoleActivationService(
       discoveryService,
@@ -664,7 +664,7 @@ public class TestRoleActivationService {
         List.of(new ProjectRole(
           roleBinding,
           ProjectRole.Status.ACTIVATED)),
-        List.of()));
+        Set.of()));
 
     var service = new RoleActivationService(
       discoveryService,
@@ -699,7 +699,7 @@ public class TestRoleActivationService {
         List.of(new ProjectRole(
           roleBinding,
           ProjectRole.Status.ELIGIBLE_FOR_JIT)),
-        List.of()));
+        Set.of()));
 
     var service = new RoleActivationService(
       discoveryService,
@@ -734,7 +734,7 @@ public class TestRoleActivationService {
         List.of(new ProjectRole(
           roleBinding,
           ProjectRole.Status.ELIGIBLE_FOR_MPA)),
-        List.of()));
+        Set.of()));
 
     var service = new RoleActivationService(
       discoveryService,

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestApiResource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestApiResource.java
@@ -357,7 +357,7 @@ public class TestApiResource {
         eq(new ProjectId("project-1"))))
       .thenReturn(new Result<>(
         List.of(),
-        List.of("warning")));
+        Set.of("warning")));
 
     var response = new RestDispatcher<>(this.resource, SAMPLE_USER)
       .get("/api/projects/project-1/roles", ApiResource.ProjectRolesResponse.class);
@@ -369,7 +369,7 @@ public class TestApiResource {
     assertEquals(0, body.roles.size());
     assertNotNull(body.warnings);
     assertEquals(1, body.warnings.size());
-    assertEquals("warning", body.warnings.get(0));
+    assertEquals("warning", body.warnings.stream().findFirst().get());
   }
 
   @Test


### PR DESCRIPTION
In some cases, the Policy Analyzer API returns the same warning message multiple times.

Fixes #91 