### PR TITLE
b/289288821 Configure maximum number of roles

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeConfiguration.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeConfiguration.java
@@ -65,7 +65,10 @@ public class RuntimeConfiguration {
     this.maxNumberOfReviewersPerActivationRequest = new IntSetting(
       List.of("ACTIVATION_REQUEST_MAX_REVIEWERS"),
       10);
-    
+    this.maxNumberOfJitRolesPerSelfApproval = new IntSetting(
+      List.of("ACTIVATION_REQUEST_MAX_ROLES"),
+      10);
+
     //
     // Backend service id (Cloud Run only).
     //
@@ -128,7 +131,7 @@ public class RuntimeConfiguration {
 
   /**
    * SMTP server for sending notifications.
-    */
+   */
   public final StringSetting smtpHost;
 
   /**
@@ -188,6 +191,11 @@ public class RuntimeConfiguration {
    * Maximum number of reviewers foa an activation request.
    */
   public final IntSetting maxNumberOfReviewersPerActivationRequest;
+
+  /**
+   * Maximum number of (JIT-) eligible roles that can be activated at once.
+   */
+  public final IntSetting maxNumberOfJitRolesPerSelfApproval;
 
   public boolean isSmtpConfigured() {
     var requiredSettings = List.of(smtpHost, smtpPort, smtpSenderName, smtpSenderAddress);

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
@@ -330,4 +330,10 @@ public class RuntimeEnvironment {
       return new NotificationService.SilentNotificationService();
     }
   }
+
+  @Produces
+  public ApiResource.Options getApiOptions() {
+    return new ApiResource.Options(
+      this.configuration.maxNumberOfJitRolesPerSelfApproval.getValue());
+  }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestApiResource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestApiResource.java
@@ -56,6 +56,7 @@ public class TestApiResource {
   private static final Pattern DEFAULT_JUSTIFICATION_PATTERN = Pattern.compile("pattern");
   private static final int DEFAULT_MIN_NUMBER_OF_REVIEWERS = 1;
   private static final int DEFAULT_MAX_NUMBER_OF_REVIEWERS = 10;
+  private static final int DEFAULT_MAX_NUMBER_OF_ROLES = 3;
   private static final String DEFAULT_HINT = "hint";
   private static final Duration DEFAULT_ACTIVATION_DURATION = Duration.ofMinutes(5);
   private static final ActivationTokenService.TokenWithExpiry SAMPLE_TOKEN_WITH_EXPIRY =
@@ -66,6 +67,7 @@ public class TestApiResource {
   @BeforeEach
   public void before() {
     this.resource = new ApiResource();
+    this.resource.options = new ApiResource.Options(DEFAULT_MAX_NUMBER_OF_ROLES);
     this.resource.logAdapter = new LogAdapter();
     this.resource.runtimeEnvironment = Mockito.mock(RuntimeEnvironment.class);
     this.resource.roleDiscoveryService = Mockito.mock(RoleDiscoveryService.class);
@@ -454,6 +456,27 @@ public class TestApiResource {
   }
 
   @Test
+  public void whenRolesExceedsLimit_ThenSelfApproveActivationReturnsError() throws Exception {
+    var request = new ApiResource.SelfActivationRequest();
+
+    request.roles = Stream
+      .generate(() -> "roles/role-x")
+      .limit(DEFAULT_MAX_NUMBER_OF_ROLES + 1)
+      .collect(Collectors.toList());
+
+    var response = new RestDispatcher<>(this.resource, SAMPLE_USER).post(
+      "/api/projects/project-1/roles/self-activate",
+      request,
+      ExceptionMappers.ErrorEntity.class);
+
+    assertEquals(400, response.getStatus());
+
+    var body = response.getBody();
+    assertNotNull(body.getMessage());
+    assertTrue(body.getMessage().contains("exceeds"));
+  }
+
+  @Test
   public void whenJustificationMissing_ThenSelfApproveActivationReturnsError() throws Exception {
     var request = new ApiResource.SelfActivationRequest();
     request.roles = List.of("roles/browser");
@@ -628,7 +651,7 @@ public class TestApiResource {
 
     var body = response.getBody();
     assertNotNull(body.getMessage());
-    assertTrue(body.getMessage().contains("reviewers are required"));
+    assertTrue(body.getMessage().contains("at least"));
   }
 
   @Test
@@ -654,7 +677,7 @@ public class TestApiResource {
 
     var body = response.getBody();
     assertNotNull(body.getMessage());
-    assertTrue(body.getMessage().contains("reviewers are required"));
+    assertTrue(body.getMessage().contains("at least"));
   }
 
   @Test


### PR DESCRIPTION
Add configuration option ACTIVATION_REQUEST_MAX_ROLES to customize how many roles users are allowed to self-activate at once.

Previously, the limit was hard-coded to 10.

Fixes #83.