### PR TITLE
Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/sources"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/sources"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add Dependabot configuration to address issue https://github.com/GoogleCloudPlatform/jit-access/issues/99.

Additionally, Dependabot needs to be enabled within the repository [Security settings](https://github.com/GoogleCloudPlatform/jit-access/security).