### PR TITLE
b/291503460 Show more descriptive message when role not grantable

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/ResourceManagerAdapter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/ResourceManagerAdapter.java
@@ -190,6 +190,21 @@ public class ResourceManagerAdapter {
     }
     catch (GoogleJsonResponseException e) {
       switch (e.getStatusCode()) {
+        case 400:
+          //
+          // One possible reason for an INVALID_ARGUMENT error is that we've tried
+          // to grant a role on a project that cannot be granted on a project at all.
+          // If that's the case, provide a more descriptive error message.
+          //
+          if (e.getDetails() != null &&
+              e.getDetails().getErrors() != null &&
+              e.getDetails().getErrors().size() > 0 &&
+              e.getDetails().getErrors().get(0).getMessage() != null &&
+              e.getDetails().getErrors().get(0).getMessage().contains("does not exist in the resource's hierarchy")) {
+            throw new AccessDeniedException(
+              String.format("The role %s cannot be granted on a project", binding.getRole()),
+              e);
+          }
         case 401:
           throw new NotAuthenticatedException("Not authenticated", e);
         case 403:

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestResourceManagerAdapter.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestResourceManagerAdapter.java
@@ -81,6 +81,25 @@ public class TestResourceManagerAdapter {
   }
 
   @Test
+  public void whenRoleNotGrantableOnProject_ThenAddProjectIamBindingThrowsException() {
+    var adapter = new ResourceManagerAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+
+    String condition =
+      IamTemporaryAccessConditions.createExpression(Instant.now(), Duration.ofMinutes(5));
+
+    assertThrows(
+      AccessDeniedException.class,
+      () ->
+        adapter.addProjectIamBinding(
+          IntegrationTestEnvironment.PROJECT_ID,
+          new Binding()
+            .setMembers(List.of("user:bob@example.com"))
+            .setRole("roles/billing.viewer"),
+          EnumSet.of(ResourceManagerAdapter.IamBindingOptions.NONE),
+          REQUEST_REASON));
+  }
+
+  @Test
   public void whenResourceIsProject_ThenAddIamProjectBindingSucceeds() throws Exception {
     var adapter = new ResourceManagerAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
 


### PR DESCRIPTION
Show a more descriptive error message to the user when they try to actviate a role that's not grantable on projects (such as Billing Viewer).

Cf #88.