### PR TITLE
b/291503460 Detect additional role-not-grantable errors

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/ResourceManagerAdapter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/ResourceManagerAdapter.java
@@ -68,6 +68,12 @@ public class ResourceManagerAdapter {
     }
   }
 
+  private static boolean isRoleNotGrantableErrorMessage(String message)
+  {
+    return message != null &&
+      (message.contains("not supported") || message.contains("does not exist"));
+  }
+
   public ResourceManagerAdapter(GoogleCredentials credentials) {
     Preconditions.checkNotNull(credentials, "credentials");
 
@@ -199,8 +205,7 @@ public class ResourceManagerAdapter {
           if (e.getDetails() != null &&
               e.getDetails().getErrors() != null &&
               e.getDetails().getErrors().size() > 0 &&
-              e.getDetails().getErrors().get(0).getMessage() != null &&
-              e.getDetails().getErrors().get(0).getMessage().contains("does not exist in the resource's hierarchy")) {
+              isRoleNotGrantableErrorMessage(e.getDetails().getErrors().get(0).getMessage())) {
             throw new AccessDeniedException(
               String.format("The role %s cannot be granted on a project", binding.getRole()),
               e);

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestResourceManagerAdapter.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestResourceManagerAdapter.java
@@ -84,9 +84,6 @@ public class TestResourceManagerAdapter {
   public void whenRoleNotGrantableOnProject_ThenAddProjectIamBindingThrowsException() {
     var adapter = new ResourceManagerAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
 
-    String condition =
-      IamTemporaryAccessConditions.createExpression(Instant.now(), Duration.ofMinutes(5));
-
     assertThrows(
       AccessDeniedException.class,
       () ->


### PR DESCRIPTION
Add additional check to detect error messages that indicate that a role isn't grantable on the resource.