### PR TITLE
b/295762643 Specify project ID in URL parameter

### DIFF
--- a/sources/src/main/resources/META-INF/resources/index.html
+++ b/sources/src/main/resources/META-INF/resources/index.html
@@ -748,7 +748,8 @@
                 // Step: Select project.
                 //
                 const requestPane = gui.requestPane;
-                requestPane.selectedProjectId = localSettings.lastProjectId;
+                requestPane.selectedProjectId = queryParameters.get("projectId") ?? localSettings.lastProjectId;
+
                 requestPane.requestStep.addHandler(async () => {
                     if (!(requestPane.selectedProjectId)) {
                         throw "Select a project";


### PR DESCRIPTION
Allow a project ID to be passed as URL parameter, and prefill 
the project selector accordingly.

Ref #130 