### PR TITLE
Run mvn clean before building inside docker container.

### DIFF
--- a/sources/Dockerfile
+++ b/sources/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /app
 COPY . ./
 
 # Build jitaccess-runner.jar
-RUN mvn package -DskipTests -Dquarkus.package.output-name=jitaccess
+RUN mvn clean package -DskipTests -Dquarkus.package.output-name=jitaccess
 
 #
 # Package stage.


### PR DESCRIPTION
In order to avoid leftover artifacts from earlier builds, run mvn clean before packaging.