### PR TITLE
Set quota project for test execution

### DIFF
--- a/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/IntegrationTestEnvironment.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/IntegrationTestEnvironment.java
@@ -85,7 +85,10 @@ public class IntegrationTestEnvironment {
         "temporary-access",
         String.format("%s@%s.iam.gserviceaccount.com", "temporary-access", PROJECT_ID));
 
-      APPLICATION_CREDENTIALS = GoogleCredentials.getApplicationDefault();
+      APPLICATION_CREDENTIALS = GoogleCredentials
+        .getApplicationDefault()
+        .createWithQuotaProject(PROJECT_ID.id);;
+
       NO_ACCESS_CREDENTIALS = impersonate(APPLICATION_CREDENTIALS, NO_ACCESS_USER.email);
       TEMPORARY_ACCESS_CREDENTIALS = impersonate(APPLICATION_CREDENTIALS, TEMPORARY_ACCESS_USER.email);
     }


### PR DESCRIPTION
Explicitly set the quota project so that tests can be run as a normal user account.