### PR TITLE
fix: Double Semi in IntegrationTestEnvironment.java

### DIFF
--- a/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/IntegrationTestEnvironment.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/IntegrationTestEnvironment.java
@@ -87,7 +87,7 @@ public class IntegrationTestEnvironment {
 
       APPLICATION_CREDENTIALS = GoogleCredentials
         .getApplicationDefault()
-        .createWithQuotaProject(PROJECT_ID.id);;
+        .createWithQuotaProject(PROJECT_ID.id);
 
       NO_ACCESS_CREDENTIALS = impersonate(APPLICATION_CREDENTIALS, NO_ACCESS_USER.email);
       TEMPORARY_ACCESS_CREDENTIALS = impersonate(APPLICATION_CREDENTIALS, TEMPORARY_ACCESS_USER.email);


### PR DESCRIPTION
Removes an extra semicolon/empty statement. 