### PR TITLE
b/314022379 Apply timeout settings from configuration

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/IamCredentialsAdapter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/IamCredentialsAdapter.java
@@ -26,7 +26,6 @@ import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.json.webtoken.JsonWebToken;
 import com.google.api.services.iamcredentials.v1.IAMCredentials;
 import com.google.api.services.iamcredentials.v1.model.SignJwtRequest;
-import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.core.AccessDeniedException;
@@ -47,6 +46,7 @@ public class IamCredentialsAdapter {
   public static final String OAUTH_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
 
   private final GoogleCredentials credentials;
+  private final HttpTransport.Options httpOptions;
 
   private IAMCredentials createClient() throws IOException
   {
@@ -55,7 +55,7 @@ public class IamCredentialsAdapter {
         .Builder(
           HttpTransport.newTransport(),
           new GsonFactory(),
-          new HttpCredentialsAdapter(this.credentials))
+          HttpTransport.newAuthenticatingRequestInitializer(this.credentials, this.httpOptions))
         .setApplicationName(ApplicationVersion.USER_AGENT)
         .build();
     }
@@ -64,9 +64,14 @@ public class IamCredentialsAdapter {
     }
   }
 
-  public IamCredentialsAdapter(GoogleCredentials credentials)  {
+  public IamCredentialsAdapter(
+    GoogleCredentials credentials,
+    HttpTransport.Options httpOptions
+  )  {
     Preconditions.checkNotNull(credentials, "credentials");
+    Preconditions.checkNotNull(httpOptions, "httpOptions");
 
+    this.httpOptions = httpOptions;
     this.credentials = credentials;
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/ResourceManagerAdapter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/ResourceManagerAdapter.java
@@ -25,7 +25,6 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.cloudresourcemanager.v3.CloudResourceManager;
 import com.google.api.services.cloudresourcemanager.v3.model.*;
-import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.core.*;
@@ -50,6 +49,7 @@ public class ResourceManagerAdapter {
   private static final int SEARCH_PROJECTS_PAGE_SIZE = 1000;
 
   private final GoogleCredentials credentials;
+  private final HttpTransport.Options httpOptions;
 
   private CloudResourceManager createClient() throws IOException
   {
@@ -58,7 +58,7 @@ public class ResourceManagerAdapter {
         .Builder(
           HttpTransport.newTransport(),
           new GsonFactory(),
-          new HttpCredentialsAdapter(this.credentials))
+          HttpTransport.newAuthenticatingRequestInitializer(this.credentials, this.httpOptions))
         .setApplicationName(ApplicationVersion.USER_AGENT)
         .build();
     }
@@ -73,10 +73,15 @@ public class ResourceManagerAdapter {
       (message.contains("not supported") || message.contains("does not exist"));
   }
 
-  public ResourceManagerAdapter(GoogleCredentials credentials) {
+  public ResourceManagerAdapter(
+    GoogleCredentials credentials,
+    HttpTransport.Options httpOptions
+  ) {
     Preconditions.checkNotNull(credentials, "credentials");
+    Preconditions.checkNotNull(httpOptions, "httpOptions");
 
     this.credentials = credentials;
+    this.httpOptions = httpOptions;
   }
 
   /** Add an IAM binding using the optimistic concurrency control-mechanism. */

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/SecretManagerAdapter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/SecretManagerAdapter.java
@@ -42,19 +42,25 @@ public class SecretManagerAdapter {
   public static final String OAUTH_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
 
   private final GoogleCredentials credentials;
+  private final HttpTransport.Options httpOptions;
 
-  public SecretManagerAdapter(GoogleCredentials credentials) {
+  public SecretManagerAdapter(
+    GoogleCredentials credentials,
+    HttpTransport.Options httpOptions
+  ) {
     Preconditions.checkNotNull(credentials, "credentials");
+    Preconditions.checkNotNull(httpOptions, "httpOptions");
 
     this.credentials = credentials;
+    this.httpOptions = httpOptions;
   }
 
   private SecretManager createClient() throws IOException {
     try {
       return new SecretManager.Builder(
-        HttpTransport.newTransport(),
-        new GsonFactory(),
-        new HttpCredentialsAdapter(this.credentials))
+          HttpTransport.newTransport(),
+          new GsonFactory(),
+          HttpTransport.newAuthenticatingRequestInitializer(this.credentials, this.httpOptions))
         .setApplicationName(ApplicationVersion.USER_AGENT)
         .build();
     }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeConfiguration.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeConfiguration.java
@@ -106,11 +106,11 @@ public class RuntimeConfiguration {
       ChronoUnit.SECONDS,
       Duration.ofSeconds(5));
     this.backendReadTimeout = new DurationSetting(
-      List.of("BACKEND_CONNECT_TIMEOUT"),
+      List.of("BACKEND_READ_TIMEOUT"),
       ChronoUnit.SECONDS,
       Duration.ofSeconds(20));
     this.backendWriteTimeout = new DurationSetting(
-      List.of("BACKEND_CONNECT_TIMEOUT"),
+      List.of("BACKEND_WRITE_TIMEOUT"),
       ChronoUnit.SECONDS,
       Duration.ofSeconds(5));
   }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeConfiguration.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeConfiguration.java
@@ -24,6 +24,7 @@ package com.google.solutions.jitaccess.web;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -49,9 +50,11 @@ public class RuntimeConfiguration {
     //
     this.activationTimeout = new DurationSetting(
       List.of("ELEVATION_DURATION", "ACTIVATION_TIMEOUT"),
+      ChronoUnit.MINUTES,
       Duration.ofHours(2));
     this.activationRequestTimeout = new DurationSetting(
       List.of("ACTIVATION_REQUEST_TIMEOUT"),
+      ChronoUnit.MINUTES,
       Duration.ofHours(1));
     this.justificationPattern = new StringSetting(
       List.of("JUSTIFICATION_PATTERN"),
@@ -94,6 +97,22 @@ public class RuntimeConfiguration {
     this.smtpPassword = new StringSetting(List.of("SMTP_PASSWORD"), null);
     this.smtpSecret = new StringSetting(List.of("SMTP_SECRET"), null);
     this.smtpExtraOptions = new StringSetting(List.of("SMTP_OPTIONS"), null);
+
+    //
+    // Backend settings.
+    //
+    this.backendConnectTimeout = new DurationSetting(
+      List.of("BACKEND_CONNECT_TIMEOUT"),
+      ChronoUnit.SECONDS,
+      Duration.ofSeconds(5));
+    this.backendReadTimeout = new DurationSetting(
+      List.of("BACKEND_CONNECT_TIMEOUT"),
+      ChronoUnit.SECONDS,
+      Duration.ofSeconds(20));
+    this.backendWriteTimeout = new DurationSetting(
+      List.of("BACKEND_CONNECT_TIMEOUT"),
+      ChronoUnit.SECONDS,
+      Duration.ofSeconds(5));
   }
 
   // -------------------------------------------------------------------------
@@ -209,6 +228,21 @@ public class RuntimeConfiguration {
    */
   public final StringSetting availableProjectsQuery;
 
+  /**
+   * Connect timeout for HTTP requests to backends.
+   */
+  public final DurationSetting backendConnectTimeout;
+
+  /**
+   * Read timeout for HTTP requests to backends.
+   */
+  public final DurationSetting backendReadTimeout;
+
+  /**
+   * Write timeout for HTTP requests to backends.
+   */
+  public final DurationSetting backendWriteTimeout;
+
   public boolean isSmtpConfigured() {
     var requiredSettings = List.of(smtpHost, smtpPort, smtpSenderName, smtpSenderAddress);
     return requiredSettings.stream().allMatch(s -> s.isValid());
@@ -313,13 +347,15 @@ public class RuntimeConfiguration {
   }
 
   public class DurationSetting extends Setting<Duration> {
-    public DurationSetting(Collection<String> keys, Duration defaultValue) {
+    private final ChronoUnit unit;
+    public DurationSetting(Collection<String> keys, ChronoUnit unit, Duration defaultValue) {
       super(keys, defaultValue);
+      this.unit = unit;
     }
 
     @Override
     protected Duration parse(String value) {
-      return Duration.ofMinutes(Integer.parseInt(value));
+      return Duration.of(Integer.parseInt(value), this.unit);
     }
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
@@ -337,4 +337,12 @@ public class RuntimeEnvironment {
     return new ApiResource.Options(
       this.configuration.maxNumberOfJitRolesPerSelfApproval.getValue());
   }
+
+  @Produces
+  public HttpTransport.Options getHttpTransportOptions() {
+    return new HttpTransport.Options(
+      this.configuration.backendConnectTimeout.getValue(),
+      this.configuration.backendReadTimeout.getValue(),
+      this.configuration.backendWriteTimeout.getValue());
+  }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestAssetInventoryAdapter.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestAssetInventoryAdapter.java
@@ -26,6 +26,9 @@ import com.google.solutions.jitaccess.core.NotAuthenticatedException;
 import com.google.solutions.jitaccess.core.data.UserId;
 import org.junit.jupiter.api.Test;
 
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -38,7 +41,9 @@ public class TestAssetInventoryAdapter {
   @Test
 
   public void whenUnauthenticated_ThenFindAccessibleResourcesByUserThrowsException() {
-    var adapter = new AssetInventoryAdapter(IntegrationTestEnvironment.INVALID_CREDENTIAL);
+    var adapter = new AssetInventoryAdapter(
+      IntegrationTestEnvironment.INVALID_CREDENTIAL,
+      HttpTransport.Options.DEFAULT);
 
     assertThrows(
       NotAuthenticatedException.class,
@@ -52,7 +57,9 @@ public class TestAssetInventoryAdapter {
 
   @Test
   public void whenCallerLacksPermission_ThenFindAccessibleResourcesByUserThrowsException() {
-    var adapter = new AssetInventoryAdapter(IntegrationTestEnvironment.NO_ACCESS_CREDENTIALS);
+    var adapter = new AssetInventoryAdapter(
+      IntegrationTestEnvironment.NO_ACCESS_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
 
     assertThrows(
       AccessDeniedException.class,
@@ -65,8 +72,29 @@ public class TestAssetInventoryAdapter {
   }
 
   @Test
+  public void whenRequestTimesOut_ThenFindAccessibleResourcesByUserThrowsException() {
+    var adapter = new AssetInventoryAdapter(
+      IntegrationTestEnvironment.NO_ACCESS_CREDENTIALS,
+      new HttpTransport.Options(
+        Duration.of(1, ChronoUnit.MILLIS),
+        Duration.of(1, ChronoUnit.MILLIS),
+        Duration.of(1, ChronoUnit.MILLIS)));
+
+    assertThrows(
+      SocketTimeoutException.class,
+      () -> adapter.findAccessibleResourcesByUser(
+        "projects/0",
+        new UserId("", "bob@example.com"),
+        Optional.empty(),
+        Optional.empty(),
+        true));
+  }
+
+  @Test
   public void whenPermissionDoesNotExist_ThenFindAccessibleResourcesByUserReturnsEmptyResult() throws Exception {
-    var adapter = new AssetInventoryAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var adapter = new AssetInventoryAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
 
     var result = adapter.findAccessibleResourcesByUser(
       "projects/" + IntegrationTestEnvironment.PROJECT_ID,
@@ -81,7 +109,9 @@ public class TestAssetInventoryAdapter {
 
   @Test
   public void whenResourceDoesNotExist_ThenFindAccessibleResourcesByUserReturnsEmptyResult() throws Exception {
-    var adapter = new AssetInventoryAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var adapter = new AssetInventoryAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
 
     var result = adapter.findAccessibleResourcesByUser(
       "projects/" + IntegrationTestEnvironment.PROJECT_ID,
@@ -100,7 +130,9 @@ public class TestAssetInventoryAdapter {
 
   @Test
   public void whenUnauthenticated_ThenPermissionedPrincipalsByResourceThrowsException() {
-    var adapter = new AssetInventoryAdapter(IntegrationTestEnvironment.INVALID_CREDENTIAL);
+    var adapter = new AssetInventoryAdapter(
+      IntegrationTestEnvironment.INVALID_CREDENTIAL,
+      HttpTransport.Options.DEFAULT);
 
     assertThrows(
       NotAuthenticatedException.class,
@@ -112,7 +144,9 @@ public class TestAssetInventoryAdapter {
 
   @Test
   public void whenCallerLacksPermission_ThenFindPermissionedPrincipalsByResourceThrowsException() {
-    var adapter = new AssetInventoryAdapter(IntegrationTestEnvironment.NO_ACCESS_CREDENTIALS);
+    var adapter = new AssetInventoryAdapter(
+      IntegrationTestEnvironment.NO_ACCESS_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
 
     assertThrows(
       AccessDeniedException.class,

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestIamCredentialsAdapter.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestIamCredentialsAdapter.java
@@ -15,7 +15,9 @@ public class TestIamCredentialsAdapter {
 
   @Test
   public void whenUnauthenticated_ThenSignJwtThrowsException() {
-    var adapter = new IamCredentialsAdapter(IntegrationTestEnvironment.NO_ACCESS_CREDENTIALS);
+    var adapter = new IamCredentialsAdapter(
+      IntegrationTestEnvironment.NO_ACCESS_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
 
     var payload = new JsonWebToken.Payload()
       .setAudience("test");
@@ -27,7 +29,9 @@ public class TestIamCredentialsAdapter {
 
   @Test
   public void whenCallerHasPermission_ThenSignJwtSucceeds() throws Exception {
-    var adapter = new IamCredentialsAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var adapter = new IamCredentialsAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
     var serviceAccount = IntegrationTestEnvironment.NO_ACCESS_USER;
 
     var payload = new JsonWebToken.Payload()

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestResourceManagerAdapter.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestResourceManagerAdapter.java
@@ -50,7 +50,9 @@ public class TestResourceManagerAdapter {
 
   @Test
   public void whenUnauthenticated_ThenAddIamProjectBindingThrowsException() {
-    var adapter = new ResourceManagerAdapter(IntegrationTestEnvironment.INVALID_CREDENTIAL);
+    var adapter = new ResourceManagerAdapter(
+      IntegrationTestEnvironment.INVALID_CREDENTIAL,
+      HttpTransport.Options.DEFAULT);
 
     assertThrows(
       NotAuthenticatedException.class,
@@ -66,7 +68,9 @@ public class TestResourceManagerAdapter {
 
   @Test
   public void whenCallerLacksPermission_ThenAddProjectIamBindingThrowsException() {
-    var adapter = new ResourceManagerAdapter(IntegrationTestEnvironment.NO_ACCESS_CREDENTIALS);
+    var adapter = new ResourceManagerAdapter(
+      IntegrationTestEnvironment.NO_ACCESS_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
 
     assertThrows(
       AccessDeniedException.class,
@@ -82,7 +86,9 @@ public class TestResourceManagerAdapter {
 
   @Test
   public void whenRoleNotGrantableOnProject_ThenAddProjectIamBindingThrowsException() {
-    var adapter = new ResourceManagerAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var adapter = new ResourceManagerAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
 
     assertThrows(
       AccessDeniedException.class,
@@ -98,7 +104,9 @@ public class TestResourceManagerAdapter {
 
   @Test
   public void whenResourceIsProject_ThenAddIamProjectBindingSucceeds() throws Exception {
-    var adapter = new ResourceManagerAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var adapter = new ResourceManagerAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
 
     String condition =
       IamTemporaryAccessConditions.createExpression(Instant.now(), Duration.ofMinutes(5));
@@ -115,7 +123,9 @@ public class TestResourceManagerAdapter {
 
   @Test
   public void whenPurgeExistingTemporaryBindingsFlagIsOn_ThenExistingTemporaryBindingsAreRemoved() throws Exception {
-    var adapter = new ResourceManagerAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var adapter = new ResourceManagerAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
 
     // Add an "old" temporary IAM binding.
     adapter.addProjectIamBinding(
@@ -215,7 +225,9 @@ public class TestResourceManagerAdapter {
 
   @Test
   public void whenFailIfBindingExistsFlagIsOnAndBindingExists_ThenAddProjectBindingThrowsException() throws Exception {
-    var adapter = new ResourceManagerAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var adapter = new ResourceManagerAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
 
     var newBinding = new Binding()
       .setMembers(List.of("serviceAccount:" + IntegrationTestEnvironment.TEMPORARY_ACCESS_USER.email))
@@ -388,7 +400,9 @@ public class TestResourceManagerAdapter {
 
   @Test
   public void whenUnauthenticated_ThenTestIamPermissionsThrowsException() {
-    var adapter = new ResourceManagerAdapter(IntegrationTestEnvironment.INVALID_CREDENTIAL);
+    var adapter = new ResourceManagerAdapter(
+      IntegrationTestEnvironment.INVALID_CREDENTIAL,
+      HttpTransport.Options.DEFAULT);
 
     assertThrows(
       NotAuthenticatedException.class,
@@ -399,7 +413,9 @@ public class TestResourceManagerAdapter {
 
   @Test
   public void whenAuthorized_ThenTestIamPermissionsSucceeds() throws Exception {
-    var adapter = new ResourceManagerAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var adapter = new ResourceManagerAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
 
     var heldPermissions = adapter.testIamPermissions(
       IntegrationTestEnvironment.PROJECT_ID,

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestSecretManagerAdapter.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestSecretManagerAdapter.java
@@ -97,7 +97,9 @@ public class TestSecretManagerAdapter {
 
   @Test
   public void whenUnauthenticated_ThenAccessSecretThrowsException() {
-    var adapter = new SecretManagerAdapter(IntegrationTestEnvironment.INVALID_CREDENTIAL);
+    var adapter = new SecretManagerAdapter(
+      IntegrationTestEnvironment.INVALID_CREDENTIAL,
+      HttpTransport.Options.DEFAULT);
 
     assertThrows(
       NotAuthenticatedException.class,
@@ -106,7 +108,9 @@ public class TestSecretManagerAdapter {
 
   @Test
   public void whenCallerLacksPermission_ThenAccessSecretThrowsException() {
-    var adapter = new SecretManagerAdapter(IntegrationTestEnvironment.NO_ACCESS_CREDENTIALS);
+    var adapter = new SecretManagerAdapter(
+      IntegrationTestEnvironment.NO_ACCESS_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
 
     assertThrows(
       AccessDeniedException.class,
@@ -115,7 +119,9 @@ public class TestSecretManagerAdapter {
 
   @Test
   public void whenSecretNotFondPermission_ThenAccessSecretThrowsException() {
-    var adapter = new SecretManagerAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var adapter = new SecretManagerAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
 
     assertThrows(
       ResourceNotFoundException.class,
@@ -126,7 +132,9 @@ public class TestSecretManagerAdapter {
 
   @Test
   public void whenSecretVersionNotFondPermission_ThenAccessSecretThrowsException() {
-    var adapter = new SecretManagerAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var adapter = new SecretManagerAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
 
     assertThrows(
       ResourceNotFoundException.class,

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestActivationTokenService.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/services/TestActivationTokenService.java
@@ -23,6 +23,7 @@ package com.google.solutions.jitaccess.core.services;
 
 import com.google.api.client.json.webtoken.JsonWebToken;
 import com.google.auth.oauth2.TokenVerifier;
+import com.google.solutions.jitaccess.core.adapters.HttpTransport;
 import com.google.solutions.jitaccess.core.adapters.IamCredentialsAdapter;
 import com.google.solutions.jitaccess.core.adapters.IntegrationTestEnvironment;
 import com.google.solutions.jitaccess.core.data.ProjectId;
@@ -47,7 +48,9 @@ public class TestActivationTokenService {
 
   @Test
   public void createTokenAddsObligatoryClaims() throws Exception {
-    var credentialsAdapter = new IamCredentialsAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var credentialsAdapter = new IamCredentialsAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
     var serviceAccount = IntegrationTestEnvironment.NO_ACCESS_USER;
     var tokenService = new ActivationTokenService(
       credentialsAdapter,
@@ -93,7 +96,9 @@ public class TestActivationTokenService {
 
   @Test
   public void whenJwtMissesAudienceClaim_ThenVerifyTokenThrowsException() throws Exception {
-    var credentialsAdapter = new IamCredentialsAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var credentialsAdapter = new IamCredentialsAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
     var serviceAccount = IntegrationTestEnvironment.NO_ACCESS_USER;
     var tokenService = new ActivationTokenService(
       credentialsAdapter,
@@ -112,7 +117,9 @@ public class TestActivationTokenService {
 
   @Test
   public void whenJwtMissesIssuerClaim_ThenVerifyThrowsException() throws Exception {
-    var credentialsAdapter = new IamCredentialsAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var credentialsAdapter = new IamCredentialsAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
     var serviceAccount = IntegrationTestEnvironment.NO_ACCESS_USER;
     var tokenService = new ActivationTokenService(
       credentialsAdapter,
@@ -131,7 +138,9 @@ public class TestActivationTokenService {
 
   @Test
   public void whenJwtSignedByWrongServiceAccount_ThenVerifyThrowsException() throws Exception {
-    var credentialsAdapter = new IamCredentialsAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var credentialsAdapter = new IamCredentialsAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
     var serviceAccount = IntegrationTestEnvironment.TEMPORARY_ACCESS_USER;
     var tokenService = new ActivationTokenService(
       credentialsAdapter,
@@ -151,7 +160,9 @@ public class TestActivationTokenService {
 
   @Test
   public void whenJwtValid_ThenVerifySucceeds() throws Exception {
-    var credentialsAdapter = new IamCredentialsAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+    var credentialsAdapter = new IamCredentialsAdapter(
+      IntegrationTestEnvironment.APPLICATION_CREDENTIALS,
+      HttpTransport.Options.DEFAULT);
     var serviceAccount = IntegrationTestEnvironment.NO_ACCESS_USER;
     var tokenService = new ActivationTokenService(
       credentialsAdapter,


### PR DESCRIPTION
Allow timeout settings for backend HTTP requests to be configured using the following options:

* `BACKEND_CONNECT_TIMEOUT` (in seconds)
* `BACKEND_READ_TIMEOUT` (in seconds)
* `BACKEND_WRITE_TIMEOUT` (in seconds)

Previously, the application has used the default 20 second read-timeout imposed by the Java client libraries. This timeout can be too restrictive, especially for Policy Analyzer API requests.

This is to fix #177 177