### PR TITLE
b/295100577 Allow approval when both JIT- and MPA-eligible

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/IamPolicyCatalog.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/IamPolicyCatalog.java
@@ -109,11 +109,14 @@ public class IamPolicyCatalog extends ProjectRoleCatalog {
       .findEntitlements(
         user,
         projectId,
+        EnumSet.of(activationType),
         EnumSet.of(Entitlement.Status.AVAILABLE))
       .items()
       .stream()
-      .filter(ent -> ent.activationType() == activationType)
       .collect(Collectors.toMap(ent -> ent.id(), ent -> ent));
+
+    assert userEntitlements.values().stream().allMatch(e -> e.activationType() == activationType);
+    assert userEntitlements.values().stream().allMatch(e -> e.status() == Entitlement.Status.AVAILABLE);
 
     for (var requestedEntitlement : entitlements) {
       var grantedEntitlement = userEntitlements.get(requestedEntitlement);
@@ -168,6 +171,7 @@ public class IamPolicyCatalog extends ProjectRoleCatalog {
     return this.policyAnalyzer.findEntitlements(
       user,
       projectId,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.AVAILABLE, Entitlement.Status.ACTIVE));
   }
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestIamPolicyCatalog.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestIamPolicyCatalog.java
@@ -192,6 +192,7 @@ public class TestIamPolicyCatalog {
       .findEntitlements(
         eq(SAMPLE_REQUESTING_USER),
         eq(SAMPLE_PROJECT),
+        eq(EnumSet.of(ActivationType.JIT)),
         eq(EnumSet.of(Entitlement.Status.AVAILABLE))))
       .thenReturn(new Annotated<>(new TreeSet<>(), Set.of()));
 
@@ -223,9 +224,10 @@ public class TestIamPolicyCatalog {
       .findEntitlements(
         eq(SAMPLE_REQUESTING_USER),
         eq(SAMPLE_PROJECT),
+        eq(EnumSet.of(ActivationType.JIT)),
         eq(EnumSet.of(Entitlement.Status.AVAILABLE))))
       .thenReturn(new Annotated<>(
-        new TreeSet<>(Set.of(mpaEntitlement)),
+        new TreeSet<>(Set.of()),
         Set.of()));
 
     assertThrows(
@@ -254,6 +256,7 @@ public class TestIamPolicyCatalog {
       .findEntitlements(
         eq(SAMPLE_REQUESTING_USER),
         eq(SAMPLE_PROJECT),
+        eq(EnumSet.of(ActivationType.MPA)),
         eq(EnumSet.of(Entitlement.Status.AVAILABLE))))
       .thenReturn(new Annotated<>(new TreeSet<>(), Set.of()));
 
@@ -283,6 +286,7 @@ public class TestIamPolicyCatalog {
       .findEntitlements(
         eq(SAMPLE_REQUESTING_USER),
         eq(SAMPLE_PROJECT),
+        eq(EnumSet.of(ActivationType.MPA)),
         eq(EnumSet.of(Entitlement.Status.AVAILABLE))))
       .thenReturn(new Annotated<>(
         new TreeSet<>(Set.of(mpaEntitlement)),
@@ -320,9 +324,10 @@ public class TestIamPolicyCatalog {
       .findEntitlements(
         eq(SAMPLE_REQUESTING_USER),
         eq(SAMPLE_PROJECT),
+        eq(EnumSet.of(ActivationType.MPA)),
         eq(EnumSet.of(Entitlement.Status.AVAILABLE))))
       .thenReturn(new Annotated<>(
-        new TreeSet<>(Set.of(jitEntitlement)),
+        new TreeSet<>(Set.of()),
         Set.of()));
 
     var request = Mockito.mock(JitActivationRequest.class);
@@ -355,6 +360,7 @@ public class TestIamPolicyCatalog {
       .findEntitlements(
         eq(SAMPLE_REQUESTING_USER),
         eq(SAMPLE_PROJECT),
+        eq(EnumSet.of(ActivationType.JIT)),
         eq(EnumSet.of(Entitlement.Status.AVAILABLE))))
       .thenReturn(new Annotated<>(
         new TreeSet<>(Set.of(jitEntitlement)),
@@ -392,6 +398,7 @@ public class TestIamPolicyCatalog {
       .findEntitlements(
         eq(SAMPLE_APPROVIING_USER),
         eq(SAMPLE_PROJECT),
+        eq(EnumSet.of(ActivationType.MPA)),
         eq(EnumSet.of(Entitlement.Status.AVAILABLE))))
       .thenReturn(new Annotated<>(
         new TreeSet<>(Set.of()),
@@ -428,6 +435,7 @@ public class TestIamPolicyCatalog {
       .findEntitlements(
         eq(SAMPLE_APPROVIING_USER),
         eq(SAMPLE_PROJECT),
+        eq(EnumSet.of(ActivationType.MPA)),
         eq(EnumSet.of(Entitlement.Status.AVAILABLE))))
       .thenReturn(new Annotated<>(
         new TreeSet<>(Set.of(mpaEntitlement)),
@@ -513,6 +521,7 @@ public class TestIamPolicyCatalog {
     when(policyAnalyzer.findEntitlements(
       eq(SAMPLE_REQUESTING_USER),
       eq(SAMPLE_PROJECT),
+      eq(EnumSet.of(ActivationType.JIT, ActivationType.MPA)),
       any()))
       .thenReturn(new Annotated<>(
         new TreeSet<>(Set.of()),
@@ -534,6 +543,7 @@ public class TestIamPolicyCatalog {
     verify(policyAnalyzer, times(1)).findEntitlements(
       SAMPLE_REQUESTING_USER,
       SAMPLE_PROJECT,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.AVAILABLE, Entitlement.Status.ACTIVE));
   }
 
@@ -547,6 +557,7 @@ public class TestIamPolicyCatalog {
     when(policyAnalyzer.findEntitlements(
       eq(SAMPLE_REQUESTING_USER),
       eq(SAMPLE_PROJECT),
+      eq(EnumSet.of(ActivationType.MPA)),
       any()))
       .thenReturn(new Annotated<>(
         new TreeSet<>(Set.of()),
@@ -574,12 +585,13 @@ public class TestIamPolicyCatalog {
     when(policyAnalyzer.findEntitlements(
       eq(SAMPLE_REQUESTING_USER),
       eq(SAMPLE_PROJECT),
+      eq(EnumSet.of(ActivationType.MPA)),
       any()))
       .thenReturn(new Annotated<>(
         new TreeSet<>(Set.of(new Entitlement<>(
-          role,
+          new ProjectRoleBinding(new RoleBinding(SAMPLE_PROJECT, "roles/different-role")),
           "-",
-          ActivationType.JIT,
+          ActivationType.MPA,
           Entitlement.Status.AVAILABLE))),
         Set.of()));
 
@@ -605,6 +617,7 @@ public class TestIamPolicyCatalog {
     when(policyAnalyzer.findEntitlements(
       eq(SAMPLE_REQUESTING_USER),
       eq(SAMPLE_PROJECT),
+      eq(EnumSet.of(ActivationType.MPA)),
       any()))
       .thenReturn(new Annotated<>(
         new TreeSet<>(Set.of(new Entitlement<>(

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestPolicyAnalyzer.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestPolicyAnalyzer.java
@@ -248,6 +248,7 @@ public class TestPolicyAnalyzer {
     var entitlements = service.findEntitlements(
       SAMPLE_USER,
       SAMPLE_PROJECT_ID_1,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.AVAILABLE, Entitlement.Status.ACTIVE));
 
     assertNotNull(entitlements.warnings());
@@ -279,6 +280,7 @@ public class TestPolicyAnalyzer {
     var entitlements = service.findEntitlements(
       SAMPLE_USER,
       SAMPLE_PROJECT_ID_1,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.AVAILABLE, Entitlement.Status.ACTIVE));
 
     assertNotNull(entitlements.warnings());
@@ -313,6 +315,7 @@ public class TestPolicyAnalyzer {
     var entitlements = service.findEntitlements(
       SAMPLE_USER,
       SAMPLE_PROJECT_ID_1,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.AVAILABLE, Entitlement.Status.ACTIVE));
 
     assertNotNull(entitlements.warnings());
@@ -350,6 +353,7 @@ public class TestPolicyAnalyzer {
     var entitlements = service.findEntitlements(
       SAMPLE_USER,
       SAMPLE_PROJECT_ID_1,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.AVAILABLE, Entitlement.Status.ACTIVE));
 
     assertNotNull(entitlements.warnings());
@@ -401,6 +405,7 @@ public class TestPolicyAnalyzer {
     var entitlements = service.findEntitlements(
       SAMPLE_USER,
       SAMPLE_PROJECT_ID_1,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.AVAILABLE, Entitlement.Status.ACTIVE));
 
     assertNotNull(entitlements.warnings());
@@ -445,6 +450,7 @@ public class TestPolicyAnalyzer {
     var entitlements = service.findEntitlements(
       SAMPLE_USER,
       SAMPLE_PROJECT_ID_1,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.AVAILABLE, Entitlement.Status.ACTIVE));
 
     assertNotNull(entitlements.warnings());
@@ -496,6 +502,7 @@ public class TestPolicyAnalyzer {
     var entitlements = service.findEntitlements(
       SAMPLE_USER,
       SAMPLE_PROJECT_ID_1,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.AVAILABLE, Entitlement.Status.ACTIVE));
 
     assertNotNull(entitlements.warnings());
@@ -549,6 +556,7 @@ public class TestPolicyAnalyzer {
     var entitlements = service.findEntitlements(
       SAMPLE_USER,
       SAMPLE_PROJECT_ID_1,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.AVAILABLE, Entitlement.Status.ACTIVE));
 
     assertNotNull(entitlements.warnings());
@@ -607,6 +615,7 @@ public class TestPolicyAnalyzer {
     var entitlements = service.findEntitlements(
       SAMPLE_USER,
       SAMPLE_PROJECT_ID_1,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.AVAILABLE, Entitlement.Status.ACTIVE));
 
     assertNotNull(entitlements.warnings());
@@ -672,6 +681,7 @@ public class TestPolicyAnalyzer {
     var entitlements = service.findEntitlements(
       SAMPLE_USER,
       SAMPLE_PROJECT_ID_1,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.AVAILABLE, Entitlement.Status.ACTIVE));
 
     assertNotNull(entitlements.warnings());
@@ -716,6 +726,7 @@ public class TestPolicyAnalyzer {
     var entitlements = service.findEntitlements(
       SAMPLE_USER,
       SAMPLE_PROJECT_ID_1,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.AVAILABLE, Entitlement.Status.ACTIVE));
 
     assertNotNull(entitlements.warnings());
@@ -772,6 +783,7 @@ public class TestPolicyAnalyzer {
     var entitlements = service.findEntitlements(
       SAMPLE_USER,
       SAMPLE_PROJECT_ID_1,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.AVAILABLE, Entitlement.Status.ACTIVE));
 
     assertNotNull(entitlements.warnings());
@@ -845,6 +857,7 @@ public class TestPolicyAnalyzer {
     var entitlements = service.findEntitlements(
       SAMPLE_USER,
       SAMPLE_PROJECT_ID_1,
+      EnumSet.of(ActivationType.JIT, ActivationType.MPA),
       EnumSet.of(Entitlement.Status.ACTIVE));
 
     assertNotNull(entitlements.warnings());


### PR DESCRIPTION
Fixes an issue where approving MPA request fails if user is both JIT- and MPA-eligible for requested role.