### PR TITLE
b/325335791 Extend existing activation

### DIFF
--- a/sources/src/main/resources/META-INF/resources/index.html
+++ b/sources/src/main/resources/META-INF/resources/index.html
@@ -597,8 +597,7 @@
                                     (item.validUntil == null ? "" : ` (${Math.floor((item.validUntil * 1000 - new Date()) / (60*1000))} minutes left)`), 
                               class: item.status === "ACTIVE" ? "activated" : null }
                         ],
-                        true,
-                        item.status !== "ACTIVE");
+                        true);
                 });
             }
 


### PR DESCRIPTION
Allow users to extend an activation by requesting it again.

No backend changes required as the backend (as of 1.6) 
ignores existing activations in the authorization check.

Implements #141 