### PR TITLE
b/325372861 Add CatalogUserContext

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/Catalog.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/Catalog.java
@@ -23,6 +23,7 @@ package com.google.solutions.jitaccess.core.catalog;
 
 import com.google.solutions.jitaccess.core.AccessException;
 import com.google.solutions.jitaccess.core.auth.UserEmail;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.util.SortedSet;
@@ -32,37 +33,49 @@ import java.util.SortedSet;
  *
  * The catalog is scoped to a project.
  */
-public interface EntitlementCatalog
-  <TEntitlementId extends EntitlementId, TScopeId extends ResourceId> {
+public interface Catalog<
+  TEntitlementId extends EntitlementId,
+  TScopeId extends ResourceId,
+  TUserContext extends CatalogUserContext
+  > {
+
+  /**
+   * Capture context information for the user interacting
+   * with the catalog.
+   */
+  @NotNull TUserContext createContext(
+    @NotNull UserEmail user
+  ) throws AccessException, IOException;
 
   /**
    * Verify if a user is allowed to make the given request.
    */
   void verifyUserCanRequest(
-    ActivationRequest<TEntitlementId> request
+    @NotNull TUserContext userContext,
+    @NotNull ActivationRequest<TEntitlementId> request
   ) throws AccessException, IOException;
 
   /**
    * Verify if a user is allowed to approve a given request.
    */
   void verifyUserCanApprove(
-    UserEmail approvingUser,
-    MpaActivationRequest<TEntitlementId> request
+    @NotNull TUserContext userContext,
+    @NotNull MpaActivationRequest<TEntitlementId> request
   ) throws AccessException, IOException;
 
   /**
    * List scopes that the user has any entitlements for.
    */
   SortedSet<TScopeId> listScopes(
-    UserEmail user
-  ) throws AccessException, IOException;
+    @NotNull TUserContext userContext
+    ) throws AccessException, IOException;
 
   /**
    * List available reviewers for (MPA-) activating an entitlement.
    */
   SortedSet<UserEmail> listReviewers(
-    UserEmail requestingUser,
-    TEntitlementId entitlement
+    @NotNull TUserContext userContext,
+    @NotNull TEntitlementId entitlement
   ) throws AccessException, IOException;
 
 
@@ -70,7 +83,7 @@ public interface EntitlementCatalog
    * List available entitlements.
    */
   EntitlementSet<TEntitlementId> listEntitlements(
-    UserEmail user,
+    TUserContext userContext,
     TScopeId scope
   ) throws AccessException, IOException;
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/CatalogUserContext.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/CatalogUserContext.java
@@ -1,0 +1,36 @@
+//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.google.solutions.jitaccess.core.catalog;
+
+import com.google.solutions.jitaccess.core.auth.UserEmail;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Captures context information about the user interacting
+ * with the catalog.
+ */
+public interface CatalogUserContext {
+  /**
+   * @return ID of the user.
+   */
+  @NotNull UserEmail user();
+}

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectRoleActivator.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectRoleActivator.java
@@ -44,11 +44,14 @@ import java.util.stream.Collectors;
  * Activator for project roles.
  */
 @Dependent
-public class ProjectRoleActivator extends EntitlementActivator<ProjectRoleBinding, ProjectId> {
+public class ProjectRoleActivator extends EntitlementActivator<
+  ProjectRoleBinding,
+  ProjectId,
+  MpaProjectRoleCatalog.UserContext> {
   private final @NotNull ResourceManagerClient resourceManagerClient;
 
   public ProjectRoleActivator(
-    EntitlementCatalog<ProjectRoleBinding, ProjectId> catalog,
+    @NotNull Catalog<ProjectRoleBinding, ProjectId, MpaProjectRoleCatalog.UserContext> catalog,
     @NotNull ResourceManagerClient resourceManagerClient,
     @NotNull JustificationPolicy policy
   ) {

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestApiResource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestApiResource.java
@@ -81,6 +81,9 @@ public class TestApiResource {
     this.resource.logAdapter = new LogAdapter();
     this.resource.runtimeEnvironment = Mockito.mock(RuntimeEnvironment.class);
     this.resource.mpaCatalog = Mockito.mock(MpaProjectRoleCatalog.class);
+    when (this.resource.mpaCatalog.createContext(any()))
+      .thenAnswer(inv -> new MpaProjectRoleCatalog.UserContext(inv.getArgument(0)));
+
     this.resource.projectRoleActivator = Mockito.mock(ProjectRoleActivator.class);
     this.resource.justificationPolicy = Mockito.mock(JustificationPolicy.class);
     this.resource.tokenSigner = Mockito.mock(TokenSigner.class);
@@ -168,7 +171,7 @@ public class TestApiResource {
 
   @Test
   public void whenProjectDiscoveryThrowsAccessDeniedException_ThenListProjectsReturnsError() throws Exception {
-    when(this.resource.mpaCatalog.listScopes(eq(SAMPLE_USER)))
+    when(this.resource.mpaCatalog.listScopes(argThat(ctx -> ctx.user().equals(SAMPLE_USER))))
       .thenThrow(new AccessDeniedException("mock"));
 
     var response = new RestDispatcher<>(this.resource, SAMPLE_USER)
@@ -182,7 +185,7 @@ public class TestApiResource {
 
   @Test
   public void whenProjectDiscoveryThrowsIOException_ThenListProjectsReturnsError() throws Exception {
-    when(this.resource.mpaCatalog.listScopes(eq(SAMPLE_USER)))
+    when(this.resource.mpaCatalog.listScopes(argThat(ctx -> ctx.user().equals(SAMPLE_USER))))
       .thenThrow(new IOException("mock"));
 
     var response = new RestDispatcher<>(this.resource, SAMPLE_USER)
@@ -196,7 +199,7 @@ public class TestApiResource {
 
   @Test
   public void whenProjectDiscoveryReturnsNoProjects_ThenListProjectsReturnsEmptyList() throws Exception {
-    when(this.resource.mpaCatalog.listScopes(eq(SAMPLE_USER)))
+    when(this.resource.mpaCatalog.listScopes(argThat(ctx -> ctx.user().equals(SAMPLE_USER))))
       .thenReturn(new TreeSet<>());
 
     var response = new RestDispatcher<>(this.resource, SAMPLE_USER)
@@ -211,7 +214,7 @@ public class TestApiResource {
 
   @Test
   public void whenProjectDiscoveryReturnsProjects_ThenListProjectsReturnsList() throws Exception {
-    when(this.resource.mpaCatalog.listScopes(eq(SAMPLE_USER)))
+    when(this.resource.mpaCatalog.listScopes(argThat(ctx -> ctx.user().equals(SAMPLE_USER))))
       .thenReturn(new TreeSet<>(Set.of(
         new ProjectId("project-1"),
         new ProjectId("project-2"),
@@ -254,7 +257,7 @@ public class TestApiResource {
 
   @Test
   public void whenPeerDiscoveryThrowsAccessDeniedException_ThenListPeersReturnsError() throws Exception {
-    when(this.resource.mpaCatalog.listReviewers(eq(SAMPLE_USER), any()))
+    when(this.resource.mpaCatalog.listReviewers(argThat(ctx -> ctx.user().equals(SAMPLE_USER)), any()))
       .thenThrow(new AccessDeniedException("mock"));
 
     var response = new RestDispatcher<>(this.resource, SAMPLE_USER)
@@ -268,7 +271,7 @@ public class TestApiResource {
 
   @Test
   public void whenPeerDiscoveryThrowsIOException_ThenListPeersReturnsError() throws Exception {
-    when(this.resource.mpaCatalog.listReviewers(eq(SAMPLE_USER), any()))
+    when(this.resource.mpaCatalog.listReviewers(argThat(ctx -> ctx.user().equals(SAMPLE_USER)), any()))
       .thenThrow(new IOException("mock"));
 
     var response = new RestDispatcher<>(this.resource, SAMPLE_USER)
@@ -284,7 +287,7 @@ public class TestApiResource {
   public void whenPeerDiscoveryReturnsNoPeers_ThenListPeersReturnsEmptyList() throws Exception {
     when(this.resource.mpaCatalog
       .listReviewers(
-        eq(SAMPLE_USER),
+        argThat(ctx -> ctx.user().equals(SAMPLE_USER)),
         argThat(r -> r.roleBinding().role().equals("roles/browser"))))
       .thenReturn(new TreeSet());
 
@@ -302,7 +305,7 @@ public class TestApiResource {
   public void whenPeerDiscoveryReturnsProjects_ThenListPeersReturnsList() throws Exception {
     when(this.resource.mpaCatalog
       .listReviewers(
-        eq(SAMPLE_USER),
+        argThat(ctx -> ctx.user().equals(SAMPLE_USER)),
         argThat(r -> r.roleBinding().role().equals("roles/browser"))))
       .thenReturn(new TreeSet(Set.of(new UserEmail("peer-1@example.com"), new UserEmail("peer-2@example.com"))));
 
@@ -330,7 +333,7 @@ public class TestApiResource {
 
   @Test
   public void whenProjectIsEmpty_ThenListRolesReturnsError() throws Exception {
-    when(this.resource.mpaCatalog.listScopes(eq(SAMPLE_USER)))
+    when(this.resource.mpaCatalog.listScopes(argThat(ctx -> ctx.user().equals(SAMPLE_USER))))
       .thenThrow(new AccessDeniedException("mock"));
 
     var response = new RestDispatcher<>(this.resource, SAMPLE_USER)
@@ -347,7 +350,7 @@ public class TestApiResource {
   public void whenCatalogThrowsAccessDeniedException_ThenListRolesReturnsError() throws Exception {
     when(this.resource.mpaCatalog
       .listEntitlements(
-        eq(SAMPLE_USER),
+        argThat(ctx -> ctx.user().equals(SAMPLE_USER)),
         eq(new ProjectId("project-1"))))
       .thenThrow(new AccessDeniedException("mock"));
 
@@ -364,7 +367,7 @@ public class TestApiResource {
   public void whenCatalogThrowsIOException_ThenListRolesReturnsError() throws Exception {
     when(this.resource.mpaCatalog
       .listEntitlements(
-        eq(SAMPLE_USER),
+        argThat(ctx -> ctx.user().equals(SAMPLE_USER)),
         eq(new ProjectId("project-1"))))
       .thenThrow(new IOException("mock"));
 
@@ -381,7 +384,7 @@ public class TestApiResource {
   public void whenCatalogReturnsNoRoles_ThenListRolesReturnsEmptyList() throws Exception {
     when(this.resource.mpaCatalog
       .listEntitlements(
-        eq(SAMPLE_USER),
+        argThat(ctx -> ctx.user().equals(SAMPLE_USER)),
         eq(new ProjectId("project-1"))))
       .thenReturn(new EntitlementSet<>(
         new TreeSet<>(Set.of()),
@@ -416,7 +419,7 @@ public class TestApiResource {
 
     when(this.resource.mpaCatalog
       .listEntitlements(
-        eq(SAMPLE_USER),
+        argThat(ctx -> ctx.user().equals(SAMPLE_USER)),
         eq(new ProjectId("project-1"))))
       .thenReturn(new EntitlementSet<>(
         new TreeSet<>(Set.of(role1, role2)),
@@ -531,7 +534,9 @@ public class TestApiResource {
       .createJitRequest(any(), any(), any(), any(), any()))
       .thenCallRealMethod();
     when(this.resource.projectRoleActivator
-      .activate(any()))
+      .activate(
+        argThat(ctx -> ctx.user().equals(SAMPLE_USER)),
+        any()))
       .thenThrow(new AccessDeniedException("mock"));
 
     var request = new ApiResource.SelfActivationRequest();
@@ -557,8 +562,10 @@ public class TestApiResource {
       .createJitRequest(any(), any(), any(), any(), any()))
       .thenCallRealMethod();
     when(this.resource.projectRoleActivator
-      .activate(argThat(r -> r.entitlements().size() == 1)))
-      .then(r -> new Activation<>((ActivationRequest<ProjectRoleBinding>) r.getArguments()[0]));
+      .activate(
+        argThat(ctx -> ctx.user().equals(SAMPLE_USER)),
+        argThat(r -> r.entitlements().size() == 1)))
+      .then(r -> new Activation<>((ActivationRequest<ProjectRoleBinding>) r.getArguments()[1]));
 
     var request = new ApiResource.SelfActivationRequest();
     request.roles = List.of("roles/browser", "roles/browser");
@@ -793,7 +800,7 @@ public class TestApiResource {
 
     when(this.resource.projectRoleActivator
       .createMpaRequest(
-        eq(SAMPLE_USER),
+        argThat(ctx -> ctx.user().equals(SAMPLE_USER)),
         any(),
         any(),
         any(),
@@ -930,11 +937,11 @@ public class TestApiResource {
   @Test
   public void whenCallerNotInvolvedInRequest_ThenGetActivationRequestReturnsError() throws Exception {
     var request = new ProjectRoleActivator(
-      Mockito.mock(EntitlementCatalog.class),
+      Mockito.mock(Catalog.class),
       Mockito.mock(ResourceManagerClient.class),
       Mockito.mock(JustificationPolicy.class))
       .createMpaRequest(
-        SAMPLE_USER,
+        new MpaProjectRoleCatalog.UserContext(SAMPLE_USER),
         Set.of(new ProjectRoleBinding(new RoleBinding(new ProjectId("project-1"), "roles/mock"))),
         Set.of(SAMPLE_USER_2),
         "a justification",
@@ -963,11 +970,11 @@ public class TestApiResource {
   @Test
   public void whenTokenValid_ThenGetActivationRequestSucceeds() throws Exception {
     var request = new ProjectRoleActivator(
-      Mockito.mock(EntitlementCatalog.class),
+      Mockito.mock(Catalog.class),
       Mockito.mock(ResourceManagerClient.class),
       Mockito.mock(JustificationPolicy.class))
       .createMpaRequest(
-        SAMPLE_USER,
+        new MpaProjectRoleCatalog.UserContext(SAMPLE_USER),
         Set.of(new ProjectRoleBinding(new RoleBinding(new ProjectId("project-1"), "roles/mock"))),
         Set.of(SAMPLE_USER_2),
         "a justification",
@@ -1038,11 +1045,11 @@ public class TestApiResource {
   @Test
   public void whenActivatorThrowsException_ThenApproveActivationRequestReturnsError() throws Exception {
     var request = new ProjectRoleActivator(
-      Mockito.mock(EntitlementCatalog.class),
+      Mockito.mock(Catalog.class),
       Mockito.mock(ResourceManagerClient.class),
       Mockito.mock(JustificationPolicy.class))
       .createMpaRequest(
-        SAMPLE_USER,
+        new MpaProjectRoleCatalog.UserContext(SAMPLE_USER),
         Set.of(new ProjectRoleBinding(new RoleBinding(new ProjectId("project-1"), "roles/mock"))),
         Set.of(SAMPLE_USER_2),
         "a justification",
@@ -1057,7 +1064,7 @@ public class TestApiResource {
 
     when(this.resource.projectRoleActivator
       .approve(
-        eq(SAMPLE_USER),
+        argThat(ctx -> ctx.user().equals(SAMPLE_USER)),
         eq(request)))
       .thenThrow(new AccessDeniedException("mock"));
 
@@ -1076,11 +1083,11 @@ public class TestApiResource {
   @Test
   public void whenTokenValid_ThenApproveActivationSendsNotification() throws Exception {
     var request = new ProjectRoleActivator(
-      Mockito.mock(EntitlementCatalog.class),
+      Mockito.mock(Catalog.class),
       Mockito.mock(ResourceManagerClient.class),
       Mockito.mock(JustificationPolicy.class))
       .createMpaRequest(
-        SAMPLE_USER,
+        new MpaProjectRoleCatalog.UserContext(SAMPLE_USER),
         Set.of(new ProjectRoleBinding(new RoleBinding(new ProjectId("project-1"), "roles/mock"))),
         Set.of(SAMPLE_USER_2),
         "a justification",
@@ -1095,7 +1102,7 @@ public class TestApiResource {
 
     when(this.resource.projectRoleActivator
       .approve(
-        eq(SAMPLE_USER),
+        argThat(ctx -> ctx.user().equals(SAMPLE_USER)),
         eq(request)))
       .thenReturn(new Activation<>(request));
 
@@ -1113,11 +1120,11 @@ public class TestApiResource {
   @Test
   public void whenTokenValid_ThenApproveActivationRequestSucceeds() throws Exception {
     var request = new ProjectRoleActivator(
-      Mockito.mock(EntitlementCatalog.class),
+      Mockito.mock(Catalog.class),
       Mockito.mock(ResourceManagerClient.class),
       Mockito.mock(JustificationPolicy.class))
       .createMpaRequest(
-        SAMPLE_USER,
+        new MpaProjectRoleCatalog.UserContext(SAMPLE_USER),
         Set.of(new ProjectRoleBinding(new RoleBinding(new ProjectId("project-1"), "roles/mock"))),
         Set.of(SAMPLE_USER_2),
         "a justification",
@@ -1132,7 +1139,7 @@ public class TestApiResource {
 
     when(this.resource.projectRoleActivator
       .approve(
-        eq(SAMPLE_USER_2),
+        argThat(ctx -> ctx.user().equals(SAMPLE_USER_2)),
         eq(request)))
       .thenReturn(new Activation<>(request));
 


### PR DESCRIPTION
Add context object to capture information about the current user that's interacting with the catalog. 

Using a dedicated object helps avoid mixing up the interactive user with other users, and enables catalogs to look up and use additional user information such as group memberships.