### PR TITLE
b/325372861 Handle not-found case when listing memberships

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/clients/CloudIdentityGroupsClient.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/clients/CloudIdentityGroupsClient.java
@@ -103,7 +103,7 @@ public class CloudIdentityGroupsClient {
       case 403:
         throw new AccessDeniedException("Not found or access denied", e);
       case 404:
-        throw new NotFoundException("Not found", e);
+        throw new ResourceNotFoundException("Not found", e);
       default:
         throw (GoogleJsonResponseException)e.fillInStackTrace();
     }
@@ -588,7 +588,17 @@ public class CloudIdentityGroupsClient {
       return Collections.unmodifiableList(result);
     }
     catch (GoogleJsonResponseException e) {
-      translateAndThrowApiException(e);
+      if (e.getStatusCode() == 500) {
+        //
+        // The API returns a 500 if the user is invalid,
+        // treat as a 404 instead.
+        //
+        throw new ResourceNotFoundException("Not found", e);
+      }
+      else {
+        translateAndThrowApiException(e);
+      }
+
       return null;
     }
   }

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/clients/ITestCloudIdentityGroupsClient.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/clients/ITestCloudIdentityGroupsClient.java
@@ -24,7 +24,6 @@ package com.google.solutions.jitaccess.core.clients;
 import com.google.solutions.jitaccess.core.*;
 import com.google.solutions.jitaccess.core.auth.GroupEmail;
 import com.google.solutions.jitaccess.core.auth.UserEmail;
-import jakarta.ws.rs.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +37,7 @@ public class ITestCloudIdentityGroupsClient {
   private static final GroupEmail TEST_GROUP_EMAIL = new GroupEmail(
     String.format(
       "jitaccess-test@%s",
-      ITestEnvironment.CLOUD_IDENTITY_DOAMIN));
+      ITestEnvironment.CLOUD_IDENTITY_DOMAIN));
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -99,7 +98,7 @@ public class ITestCloudIdentityGroupsClient {
       AccessDeniedException.class,
       () -> client.getGroup(new GroupEmail(String.format(
         "jitaccess-doesnotexist@%s",
-        ITestEnvironment.CLOUD_IDENTITY_DOAMIN))));
+        ITestEnvironment.CLOUD_IDENTITY_DOMAIN))));
   }
 
   @Test
@@ -401,7 +400,7 @@ public class ITestCloudIdentityGroupsClient {
     // Check deletion was effective.
     //
     assertThrows(
-      NotFoundException.class,
+      ResourceNotFoundException.class,
       () -> client.getMembership(id));
   }
 
@@ -467,6 +466,20 @@ public class ITestCloudIdentityGroupsClient {
       NotAuthenticatedException.class,
       () -> client.listMembershipsByUser(
         ITestEnvironment.TEMPORARY_ACCESS_USER));
+  }
+
+  @Test
+  public void whenUserNotFound_ThenListMembershipsByUserThrowsException() {
+    var client = new CloudIdentityGroupsClient(
+      ITestEnvironment.APPLICATION_CREDENTIALS,
+      new CloudIdentityGroupsClient.Options(
+        ITestEnvironment.CLOUD_IDENTITY_ACCOUNT_ID),
+      HttpTransport.Options.DEFAULT);
+
+    assertThrows(
+      ResourceNotFoundException.class,
+      () -> client.listMembershipsByUser(
+      new UserEmail("doesnotexist@" + ITestEnvironment.CLOUD_IDENTITY_DOMAIN)));
   }
 
   @Test

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/clients/ITestEnvironment.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/clients/ITestEnvironment.java
@@ -82,7 +82,7 @@ public class ITestEnvironment {
   /**
    * Domain name of the Cloud Identity/Workspace account.
    */
-  public static final String CLOUD_IDENTITY_DOAMIN;
+  public static final String CLOUD_IDENTITY_DOMAIN;
 
   public static final PubSubTopic PUBSUB_TOPIC;
 
@@ -106,7 +106,7 @@ public class ITestEnvironment {
 
       PROJECT_ID = new ProjectId(getMandatory(settings, "test.project"));
       CLOUD_IDENTITY_ACCOUNT_ID = getMandatory(settings, "test.cloudIdentity.accountId");
-      CLOUD_IDENTITY_DOAMIN = getMandatory(settings, "test.cloudIdentity.domain");
+      CLOUD_IDENTITY_DOMAIN = getMandatory(settings, "test.cloudIdentity.domain");
 
       //
       // User settings.


### PR DESCRIPTION
Add workaround for API returning status code 500
when a user can't be found.