### PR TITLE
b/325372861 Parse relative project IDs

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/ProjectId.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/ProjectId.java
@@ -22,7 +22,9 @@
 package com.google.solutions.jitaccess.core.catalog;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * ID of a Google Cloud project.
@@ -82,8 +84,11 @@ public record ProjectId(
   /**
    * Check if the string is a well-formed project ID and can be parsed.
    */
-  public static boolean canParse(@NotNull String s) {
-    if (s.startsWith(ABSOLUTE_PREFIX) && s.indexOf('/', ABSOLUTE_PREFIX.length()) == -1) {
+  public static boolean canParse(@Nullable String s) {
+    if (Strings.isNullOrEmpty(s)) {
+      return false;
+    }
+    else if (s.startsWith(ABSOLUTE_PREFIX) && s.indexOf('/', ABSOLUTE_PREFIX.length()) == -1) {
       return true;
     }
     else if (s.startsWith(RELATIVE_PREFIX) && s.indexOf('/', RELATIVE_PREFIX.length()) == -1) {

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/PolicyAnalyzerRepository.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/PolicyAnalyzerRepository.java
@@ -97,7 +97,7 @@ public class PolicyAnalyzerRepository extends ProjectRoleRepository {
         // Collect all (supported) resources covered by these bindings/ACLs.
         .flatMap(acl -> acl.getResources()
           .stream()
-          .filter(res -> ProjectId.isProjectFullResourceName(res.getFullResourceName()))
+          .filter(res -> ProjectId.canParse(res.getFullResourceName()))
           .map(res -> new ConditionalRoleBinding(
             new RoleBinding(
               res.getFullResourceName(),
@@ -151,7 +151,7 @@ public class PolicyAnalyzerRepository extends ProjectRoleRepository {
 
     return roleBindings
       .stream()
-      .map(b -> ProjectId.fromFullResourceName(b.binding.fullResourceName()))
+      .map(b -> ProjectId.parse(b.binding.fullResourceName()))
       .collect(Collectors.toCollection(TreeSet::new));
   }
 
@@ -302,7 +302,7 @@ public class PolicyAnalyzerRepository extends ProjectRoleRepository {
   ) throws AccessException, IOException {
 
     Preconditions.checkNotNull(roleBinding, "roleBinding");
-    assert ProjectId.isProjectFullResourceName(roleBinding.roleBinding().fullResourceName());
+    assert ProjectId.canParse(roleBinding.roleBinding().fullResourceName());
 
     var analysisResult = this.policyAnalyzerClient.findPermissionedPrincipalsByResource(
       this.options.scope,

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectActivationRequest.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectActivationRequest.java
@@ -43,6 +43,6 @@ class ProjectActivationRequest {
       throw new IllegalArgumentException("Entitlements must be part of the same project");
     }
 
-    return ProjectId.fromFullResourceName(projects.stream().findFirst().get());
+    return ProjectId.parse(projects.stream().findFirst().get());
   }
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectRole.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectRole.java
@@ -38,7 +38,7 @@ public class ProjectRole extends EntitlementId {
   public ProjectRole(@NotNull RoleBinding roleBinding) {
     Preconditions.checkNotNull(roleBinding, "roleBinding");
 
-    assert ProjectId.isProjectFullResourceName(roleBinding.fullResourceName());
+    assert ProjectId.canParse(roleBinding.fullResourceName());
 
     this.roleBinding = roleBinding;
   }
@@ -58,6 +58,6 @@ public class ProjectRole extends EntitlementId {
   }
 
   public @NotNull ProjectId projectId() {
-    return ProjectId.fromFullResourceName(this.roleBinding.fullResourceName());
+    return ProjectId.parse(this.roleBinding.fullResourceName());
   }
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ApiResource.java
@@ -688,7 +688,7 @@ public class ApiResource {
       //
       // Notify listeners.
       //
-      var projectId = ProjectId.fromFullResourceName(roleBinding.fullResourceName());
+      var projectId = ProjectId.parse(roleBinding.fullResourceName());
       for (var service : this.notificationServices) {
         service.sendNotification(new ActivationApprovedNotification(
           projectId,
@@ -774,7 +774,7 @@ public class ApiResource {
     return entry
       .addLabel("role", roleBinding.role())
       .addLabel("resource", roleBinding.fullResourceName())
-      .addLabel("project_id", ProjectId.fromFullResourceName(roleBinding.fullResourceName()).id());
+      .addLabel("project_id", ProjectId.parse(roleBinding.fullResourceName()).id());
   }
 
   private static LogAdapter.LogEntry addLabels(
@@ -956,7 +956,7 @@ public class ApiResource {
         assert endTime.isAfter(startTime);
 
         this.activationId = activationId.toString();
-        this.projectId = ProjectId.fromFullResourceName(roleBinding.fullResourceName()).id();
+        this.projectId = ProjectId.parse(roleBinding.fullResourceName()).id();
         this.roleBinding = roleBinding;
         this.status = status;
         this.startTime = startTime.getEpochSecond();

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/TestProjectId.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/TestProjectId.java
@@ -21,7 +21,6 @@
 
 package com.google.solutions.jitaccess.core.catalog;
 
-import com.google.solutions.jitaccess.core.catalog.ProjectId;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -39,31 +38,47 @@ public class TestProjectId {
   }
 
   // -------------------------------------------------------------------------
-  // Full resource name conversion.
+  // parse.
   // -------------------------------------------------------------------------
 
   @Test
-  public void getFullResourceNameReturnsFullyQualifiedName() {
-    assertEquals(
-      "//cloudresourcemanager.googleapis.com/projects/project-1",
-      new ProjectId("project-1").getFullResourceName());
+  public void whenProjectIdHasAbsolutePrefix_ThenParseSucceeds() {
+    var s = ProjectId.ABSOLUTE_PREFIX + "project-1";
+
+    assertTrue(ProjectId.canParse(s));
+    assertEquals("project-1", ProjectId.parse(s).id());
   }
 
   @Test
-  public void fromFullResourceNameReturnsProjectId() {
-    assertEquals(
-      new ProjectId("project-1"),
-      ProjectId.fromFullResourceName("//cloudresourcemanager.googleapis.com/projects/project-1"));
+  public void whenProjectIdHasRelativePrefix_ThenParseSucceeds() {
+    var s = ProjectId.RELATIVE_PREFIX + "project-1";
+
+    assertTrue(ProjectId.canParse(s));
+    assertEquals("project-1", ProjectId.parse(s).id());
   }
 
   @Test
-  public void whenResourceIsProject_TheIsSupportedResourceReturnsTrue() {
-    assertTrue(ProjectId.isProjectFullResourceName(SAMPLE_PROJECT_FULLRESOURCENAME));
+  public void whenResourceIdHasAbsolutePrefix_ThenParseThrowsException() {
+    var s = ProjectId.ABSOLUTE_PREFIX + "project-1/resources/1";
+
+    assertFalse(ProjectId.canParse(s));
+    assertThrows(IllegalArgumentException.class, () -> ProjectId.parse(s).id());
   }
 
   @Test
-  public void whenResourceIsNotAProject_TheIsSupportedResourceReturnsTrue() {
-    assertFalse(ProjectId.isProjectFullResourceName(SAMPLE_PROJECT_FULLRESOURCENAME + "/foo/bar"));
+  public void whenResourceIdHasRelativePrefix_ThenParseSucceeds() {
+    var s = ProjectId.RELATIVE_PREFIX + "project-1/resources/1";
+
+    assertFalse(ProjectId.canParse(s));
+    assertThrows(IllegalArgumentException.class, () -> ProjectId.parse(s).id());
+  }
+
+  @Test
+  public void whenResourceIdHasNoPrefix_ThenParseThrowsException() {
+    var s = "project-1";
+
+    assertFalse(ProjectId.canParse(s));
+    assertThrows(IllegalArgumentException.class, () -> ProjectId.parse(s).id());
   }
 
   // -------------------------------------------------------------------------

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/TestProjectId.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/TestProjectId.java
@@ -22,6 +22,8 @@
 package com.google.solutions.jitaccess.core.catalog;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 import java.util.TreeSet;
@@ -73,10 +75,10 @@ public class TestProjectId {
     assertThrows(IllegalArgumentException.class, () -> ProjectId.parse(s).id());
   }
 
-  @Test
-  public void whenResourceIdHasNoPrefix_ThenParseThrowsException() {
-    var s = "project-1";
-
+  @ParameterizedTest
+  @ValueSource(strings = {" ", "project-1", "foo/bar", "project-1/"})
+  public void whenResourceIdInvalid_ThenParseThrowsException(String s) {
+    assertFalse(ProjectId.canParse(null));
     assertFalse(ProjectId.canParse(s));
     assertThrows(IllegalArgumentException.class, () -> ProjectId.parse(s).id());
   }


### PR DESCRIPTION
Extend ProjectID parsing logic so that it can parse both absolute and relative IDs.