### PR TITLE
b/328341070 Restructure API to better support different catalogs

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ApproveActivationRequestAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ApproveActivationRequestAction.java
@@ -36,7 +36,6 @@ import com.google.solutions.jitaccess.web.LogEvents;
 import com.google.solutions.jitaccess.web.RuntimeEnvironment;
 import com.google.solutions.jitaccess.web.TokenObfuscator;
 import com.google.solutions.jitaccess.web.iap.IapPrincipal;
-import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Instance;
 import jakarta.ws.rs.core.UriInfo;
 import org.jetbrains.annotations.NotNull;
@@ -46,7 +45,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 
-@Dependent
 public class ApproveActivationRequestAction extends AbstractActivationAction {
   private final @NotNull MpaProjectRoleCatalog catalog;
   private final @NotNull TokenSigner tokenSigner;

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/IntrospectActivationRequestAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/IntrospectActivationRequestAction.java
@@ -39,7 +39,6 @@ import jakarta.enterprise.inject.Instance;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@Dependent
 public class IntrospectActivationRequestAction extends AbstractActivationAction {
   private final @NotNull TokenSigner tokenSigner;
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ListPeersAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ListPeersAction.java
@@ -41,7 +41,6 @@ import java.util.Set;
 /**
  * List peers that are qualified to approve the activation of a role.
  */
-@Dependent
 public class ListPeersAction extends AbstractAction {
   private final @NotNull MpaProjectRoleCatalog catalog;
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ListRolesAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ListRolesAction.java
@@ -44,7 +44,6 @@ import java.util.stream.Collectors;
 /**
  * List roles (within a project) that the user can activate.
  */
-@Dependent
 public class ListRolesAction extends AbstractAction {
   private final @NotNull MpaProjectRoleCatalog catalog;
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/MetadataAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/MetadataAction.java
@@ -24,7 +24,10 @@ package com.google.solutions.jitaccess.web.actions;
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.core.ApplicationVersion;
 import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.catalog.CatalogUserContext;
+import com.google.solutions.jitaccess.core.catalog.EntitlementId;
 import com.google.solutions.jitaccess.core.catalog.JustificationPolicy;
+import com.google.solutions.jitaccess.core.catalog.ResourceId;
 import com.google.solutions.jitaccess.core.catalog.project.MpaProjectRoleCatalog;
 import com.google.solutions.jitaccess.web.LogAdapter;
 import com.google.solutions.jitaccess.web.iap.IapPrincipal;
@@ -35,7 +38,12 @@ import org.jetbrains.annotations.NotNull;
  * Get information about this instance of JIT Access.
  */
 @Dependent
-public class MetadataAction extends AbstractAction {
+public class MetadataAction<
+  TEntitlementId extends EntitlementId,
+  TScopeId extends ResourceId,
+  TUserContext extends CatalogUserContext
+  > extends AbstractAction {
+
   private final @NotNull MpaProjectRoleCatalog catalog;
   private final @NotNull JustificationPolicy justificationPolicy;
 
@@ -57,7 +65,7 @@ public class MetadataAction extends AbstractAction {
       justificationPolicy.hint(),
       iapPrincipal.email(),
       ApplicationVersion.VERSION_STRING,
-      (int)options.maxActivationDuration().toMinutes(),
+      (int)options.maxActivationDuration().toMinutes(), // TODO: move to roles resource
       Math.min(60, (int)options.maxActivationDuration().toMinutes()));
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/MetadataAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/MetadataAction.java
@@ -24,10 +24,7 @@ package com.google.solutions.jitaccess.web.actions;
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.core.ApplicationVersion;
 import com.google.solutions.jitaccess.core.auth.UserEmail;
-import com.google.solutions.jitaccess.core.catalog.CatalogUserContext;
-import com.google.solutions.jitaccess.core.catalog.EntitlementId;
 import com.google.solutions.jitaccess.core.catalog.JustificationPolicy;
-import com.google.solutions.jitaccess.core.catalog.ResourceId;
 import com.google.solutions.jitaccess.core.catalog.project.MpaProjectRoleCatalog;
 import com.google.solutions.jitaccess.web.LogAdapter;
 import com.google.solutions.jitaccess.web.iap.IapPrincipal;
@@ -37,13 +34,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Get information about this instance of JIT Access.
  */
-@Dependent
-public class MetadataAction<
-  TEntitlementId extends EntitlementId,
-  TScopeId extends ResourceId,
-  TUserContext extends CatalogUserContext
-  > extends AbstractAction {
-
+public class MetadataAction extends AbstractAction {
   private final @NotNull MpaProjectRoleCatalog catalog;
   private final @NotNull JustificationPolicy justificationPolicy;
 
@@ -65,7 +56,7 @@ public class MetadataAction<
       justificationPolicy.hint(),
       iapPrincipal.email(),
       ApplicationVersion.VERSION_STRING,
-      (int)options.maxActivationDuration().toMinutes(), // TODO: move to roles resource
+      (int)options.maxActivationDuration().toMinutes(),
       Math.min(60, (int)options.maxActivationDuration().toMinutes()));
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestActivationAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestActivationAction.java
@@ -55,7 +55,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Dependent
 public class RequestActivationAction extends AbstractActivationAction {
   private final @NotNull MpaProjectRoleCatalog catalog;
   private final @NotNull TokenSigner tokenSigner;

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestAndSelfApproveAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestAndSelfApproveAction.java
@@ -51,7 +51,6 @@ import java.util.stream.Collectors;
  * Request and self-approve one or more project roles.
  * Only allowed for JIT-eligible roles.
  */
-@Dependent
 public class RequestAndSelfApproveAction extends AbstractActivationAction {
   private final @NotNull MpaProjectRoleCatalog catalog;
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/AbstractApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/AbstractApiResource.java
@@ -19,14 +19,13 @@
 // under the License.
 //
 
-package com.google.solutions.jitaccess.web;
+package com.google.solutions.jitaccess.web.rest;
 
 import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.AccessException;
+import com.google.solutions.jitaccess.core.catalog.ResourceId;
 import com.google.solutions.jitaccess.web.iap.IapPrincipal;
 import com.google.solutions.jitaccess.web.actions.*;
-import jakarta.enterprise.context.Dependent;
-import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
@@ -40,33 +39,22 @@ import java.util.UUID;
 /**
  * REST API controller.
  */
-@Dependent
-@Path("/api/")
-public class ApiResource {
+public abstract class AbstractApiResource<TScope extends ResourceId> {
+  protected abstract MetadataAction metadataAction();
 
-  @Inject
-  MetadataAction metadataAction;
+  protected abstract ListProjectsAction listScopesAction();
 
-  @Inject
-  ListProjectsAction listProjectsAction;
+  protected abstract ListRolesAction listRolesAction();
 
-  @Inject
-  ListRolesAction listRolesAction;
+  protected abstract ListPeersAction listPeersAction();
 
-  @Inject
-  ListPeersAction listPeersAction;
+  protected abstract RequestAndSelfApproveAction requestAndSelfApproveAction();
 
-  @Inject
-  RequestAndSelfApproveAction requestAndSelfApproveAction;
+  protected abstract RequestActivationAction requestActivationAction();
 
-  @Inject
-  RequestActivationAction requestActivationAction;
+  protected abstract IntrospectActivationRequestAction introspectActivationRequestAction();
 
-  @Inject
-  IntrospectActivationRequestAction introspectActivationRequestAction;
-
-  @Inject
-  ApproveActivationRequestAction approveActivationRequestAction;
+  protected abstract ApproveActivationRequestAction approveActivationRequestAction();
 
   // -------------------------------------------------------------------------
   // REST resources.
@@ -98,7 +86,7 @@ public class ApiResource {
   public @NotNull MetadataAction.ResponseEntity getMetadata(
     @Context @NotNull SecurityContext securityContext
   ) {
-   return this.metadataAction.execute(
+   return this.metadataAction().execute(
      (IapPrincipal)securityContext.getUserPrincipal());
   }
 
@@ -111,7 +99,7 @@ public class ApiResource {
   public @NotNull ListProjectsAction.ResponseEntity listProjects(
     @Context @NotNull SecurityContext securityContext
   ) throws AccessException {
-    return this.listProjectsAction.execute(
+    return this.listScopesAction().execute(
       (IapPrincipal)securityContext.getUserPrincipal());
   }
 
@@ -125,7 +113,7 @@ public class ApiResource {
     @PathParam("projectId") @Nullable String projectIdString,
     @Context @NotNull SecurityContext securityContext
   ) throws AccessException {
-    return this.listRolesAction.execute(
+    return this.listRolesAction().execute(
       (IapPrincipal)securityContext.getUserPrincipal(),
       projectIdString);
   }
@@ -141,7 +129,7 @@ public class ApiResource {
     @QueryParam("role") @Nullable String role,
     @Context @NotNull SecurityContext securityContext
   ) throws AccessException {
-    return this.listPeersAction.execute(
+    return this.listPeersAction().execute(
       (IapPrincipal)securityContext.getUserPrincipal(),
       projectIdString,
       role);
@@ -159,7 +147,7 @@ public class ApiResource {
     @NotNull RequestAndSelfApproveAction.RequestEntity request,
     @Context @NotNull SecurityContext securityContext
   ) throws AccessDeniedException {
-    return this.requestAndSelfApproveAction.execute(
+    return this.requestAndSelfApproveAction().execute(
       (IapPrincipal)securityContext.getUserPrincipal(),
       projectIdString,
       request);
@@ -179,7 +167,7 @@ public class ApiResource {
     @Context @NotNull SecurityContext securityContext,
     @Context @NotNull UriInfo uriInfo
   ) throws AccessDeniedException {
-    return requestActivationAction.execute(
+    return requestActivationAction().execute(
       (IapPrincipal)securityContext.getUserPrincipal(),
       projectIdString,
       request,
@@ -196,7 +184,7 @@ public class ApiResource {
     @QueryParam("activation") @Nullable String obfuscatedActivationToken,
     @Context @NotNull SecurityContext securityContext
   ) throws AccessException {
-    return introspectActivationRequestAction.execute(
+    return introspectActivationRequestAction().execute(
       (IapPrincipal)securityContext.getUserPrincipal(),
       obfuscatedActivationToken);
   }
@@ -213,7 +201,7 @@ public class ApiResource {
     @Context @NotNull SecurityContext securityContext,
     @Context @NotNull UriInfo uriInfo
   ) throws AccessException {
-    return approveActivationRequestAction.execute(
+    return approveActivationRequestAction().execute(
       (IapPrincipal)securityContext.getUserPrincipal(),
       obfuscatedActivationToken,
       uriInfo);

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/AbstractApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/AbstractApiResource.java
@@ -34,6 +34,7 @@ import jakarta.ws.rs.core.UriInfo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.IOException;
 import java.util.UUID;
 
 /**
@@ -42,7 +43,7 @@ import java.util.UUID;
 public abstract class AbstractApiResource<TScope extends ResourceId> {
   protected abstract MetadataAction metadataAction();
 
-  protected abstract ListProjectsAction listScopesAction();
+  protected abstract ListScopesAction listScopesAction();
 
   protected abstract ListRolesAction listRolesAction();
 
@@ -96,9 +97,9 @@ public abstract class AbstractApiResource<TScope extends ResourceId> {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("projects")
-  public @NotNull ListProjectsAction.ResponseEntity listProjects(
+  public @NotNull ListScopesAction.ResponseEntity listProjects(
     @Context @NotNull SecurityContext securityContext
-  ) throws AccessException {
+  ) throws AccessException, IOException {
     return this.listScopesAction().execute(
       (IapPrincipal)securityContext.getUserPrincipal());
   }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
@@ -1,0 +1,72 @@
+package com.google.solutions.jitaccess.web.rest;
+
+import com.google.solutions.jitaccess.core.catalog.ProjectId;
+import com.google.solutions.jitaccess.web.actions.*;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+
+@Dependent
+@Path("/api/")
+public class ProjectApiResource extends AbstractApiResource<ProjectId> {
+
+  @Inject
+  MetadataAction metadataAction;
+
+  @Inject
+  ListProjectsAction listProjectsAction;
+
+  @Inject
+  ListRolesAction listRolesAction;
+
+  @Inject
+  ListPeersAction listPeersAction;
+
+  @Inject
+  RequestAndSelfApproveAction requestAndSelfApproveAction;
+
+  @Inject
+  RequestActivationAction requestActivationAction;
+
+  @Inject
+  IntrospectActivationRequestAction introspectActivationRequestAction;
+
+  @Inject
+  ApproveActivationRequestAction approveActivationRequestAction;
+
+  // -------------------------------------------------------------------------
+  // Overrides.
+  // -------------------------------------------------------------------------
+
+  public MetadataAction metadataAction() {
+    return metadataAction;
+  }
+
+  public ListProjectsAction listScopesAction() {
+    return listProjectsAction;
+  }
+
+  public ListRolesAction listRolesAction() {
+    return listRolesAction;
+  }
+
+  public ListPeersAction listPeersAction() {
+    return listPeersAction;
+  }
+
+  public RequestAndSelfApproveAction requestAndSelfApproveAction() {
+    return requestAndSelfApproveAction;
+  }
+
+  public RequestActivationAction requestActivationAction() {
+    return requestActivationAction;
+  }
+
+  public IntrospectActivationRequestAction introspectActivationRequestAction() {
+    return introspectActivationRequestAction;
+  }
+
+  public ApproveActivationRequestAction approveActivationRequestAction() {
+    return approveActivationRequestAction;
+  }
+}

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
@@ -4,7 +4,6 @@ import com.google.solutions.jitaccess.core.catalog.JustificationPolicy;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
 import com.google.solutions.jitaccess.core.catalog.TokenSigner;
 import com.google.solutions.jitaccess.core.catalog.project.MpaProjectRoleCatalog;
-import com.google.solutions.jitaccess.core.catalog.project.ProjectRole;
 import com.google.solutions.jitaccess.core.catalog.project.ProjectRoleActivator;
 import com.google.solutions.jitaccess.core.notifications.NotificationService;
 import com.google.solutions.jitaccess.web.LogAdapter;

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
@@ -103,4 +103,9 @@ public class ProjectApiResource extends AbstractApiResource<ProjectId> {
       this.catalog,
       this.tokenSigner);
   }
+
+  @Override
+  protected String scopeType() {
+    return "projects";
+  }
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
@@ -1,6 +1,8 @@
 package com.google.solutions.jitaccess.web.rest;
 
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
+import com.google.solutions.jitaccess.core.catalog.project.MpaProjectRoleCatalog;
+import com.google.solutions.jitaccess.core.catalog.project.ProjectRole;
 import com.google.solutions.jitaccess.web.actions.*;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
@@ -11,7 +13,10 @@ import jakarta.ws.rs.Path;
 public class ProjectApiResource extends AbstractApiResource<ProjectId> {
 
   @Inject
-  MetadataAction metadataAction;
+  MetadataAction<
+    ProjectRole,
+    ProjectId,
+    MpaProjectRoleCatalog.UserContext> metadataAction;
 
   @Inject
   ListProjectsAction listProjectsAction;

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
@@ -1,77 +1,106 @@
 package com.google.solutions.jitaccess.web.rest;
 
+import com.google.solutions.jitaccess.core.catalog.JustificationPolicy;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
+import com.google.solutions.jitaccess.core.catalog.TokenSigner;
 import com.google.solutions.jitaccess.core.catalog.project.MpaProjectRoleCatalog;
 import com.google.solutions.jitaccess.core.catalog.project.ProjectRole;
+import com.google.solutions.jitaccess.core.catalog.project.ProjectRoleActivator;
+import com.google.solutions.jitaccess.core.notifications.NotificationService;
+import com.google.solutions.jitaccess.web.LogAdapter;
+import com.google.solutions.jitaccess.web.RuntimeEnvironment;
 import com.google.solutions.jitaccess.web.actions.*;
 import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;
 
+/**
+ * REST API controller that uses a project-based catalog.
+ */
 @Dependent
 @Path("/api/")
 public class ProjectApiResource extends AbstractApiResource<ProjectId> {
 
   @Inject
-  MetadataAction<
-    ProjectRole,
-    ProjectId,
-    MpaProjectRoleCatalog.UserContext> metadataAction;
+  LogAdapter logAdapter;
 
   @Inject
-  ListProjectsAction listProjectsAction;
+  MpaProjectRoleCatalog catalog;
 
   @Inject
-  ListRolesAction listRolesAction;
+  JustificationPolicy justificationPolicy;
 
   @Inject
-  ListPeersAction listPeersAction;
+  RuntimeEnvironment runtimeEnvironment;
 
   @Inject
-  RequestAndSelfApproveAction requestAndSelfApproveAction;
+  ProjectRoleActivator activator;
 
   @Inject
-  RequestActivationAction requestActivationAction;
+  Instance<NotificationService> notificationServices;
 
   @Inject
-  IntrospectActivationRequestAction introspectActivationRequestAction;
-
-  @Inject
-  ApproveActivationRequestAction approveActivationRequestAction;
+  TokenSigner tokenSigner;
 
   // -------------------------------------------------------------------------
   // Overrides.
   // -------------------------------------------------------------------------
 
   public MetadataAction metadataAction() {
-    return metadataAction;
+    return new MetadataAction(
+      this.logAdapter,
+      this.catalog,
+      this.justificationPolicy);
   }
 
-  public ListProjectsAction listScopesAction() {
-    return listProjectsAction;
+  public ListScopesAction listScopesAction() {
+    return new ListScopesAction(this.logAdapter, this.catalog);
   }
 
   public ListRolesAction listRolesAction() {
-    return listRolesAction;
+    return new ListRolesAction(this.logAdapter, this.catalog);
   }
 
   public ListPeersAction listPeersAction() {
-    return listPeersAction;
+    return new ListPeersAction(this.logAdapter, this.catalog);
   }
 
   public RequestAndSelfApproveAction requestAndSelfApproveAction() {
-    return requestAndSelfApproveAction;
+    return new RequestAndSelfApproveAction(
+      this.logAdapter,
+      this.runtimeEnvironment,
+      this.activator,
+      this.notificationServices,
+      this.catalog);
   }
 
   public RequestActivationAction requestActivationAction() {
-    return requestActivationAction;
+    return new RequestActivationAction(
+      this.logAdapter,
+      this.runtimeEnvironment,
+      this.activator,
+      this.notificationServices,
+      this.catalog,
+      this.tokenSigner);
   }
 
   public IntrospectActivationRequestAction introspectActivationRequestAction() {
-    return introspectActivationRequestAction;
+    return new IntrospectActivationRequestAction(
+      this.logAdapter,
+      this.runtimeEnvironment,
+      this.activator,
+      this.notificationServices,
+      this.tokenSigner);
   }
 
   public ApproveActivationRequestAction approveActivationRequestAction() {
-    return approveActivationRequestAction;
+    return new ApproveActivationRequestAction(
+      this.logAdapter,
+      this.runtimeEnvironment,
+      this.activator,
+      this.notificationServices,
+      this.catalog,
+      this.tokenSigner);
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestListScopesAction.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestListScopesAction.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 
-public class TestListProjectsAction {
+public class TestListScopesAction {
   private static final UserEmail SAMPLE_USER = new UserEmail("user-1@example.com");
 
   @Test
@@ -43,7 +43,7 @@ public class TestListProjectsAction {
     when(catalog.listScopes(argThat(ctx -> ctx.user().equals(SAMPLE_USER))))
       .thenReturn(new TreeSet<>());
 
-    var action = new ListProjectsAction(new LogAdapter(), catalog);
+    var action = new ListScopesAction(new LogAdapter(), catalog);
     var response = action.execute(Mocks.createIapPrincipalMock(SAMPLE_USER));
 
     assertEquals(0, response.projects.size());
@@ -58,7 +58,7 @@ public class TestListProjectsAction {
         new ProjectId("project-2"),
         new ProjectId("project-3"))));
 
-    var action = new ListProjectsAction(new LogAdapter(), catalog);
+    var action = new ListScopesAction(new LogAdapter(), catalog);
     var response = action.execute(Mocks.createIapPrincipalMock(SAMPLE_USER));
 
     assertNotNull(response.projects);


### PR DESCRIPTION
* Extract abstract JAX-RS resource class that is neutral w.r.t. catalog and scopes
* Move catalog-specific initialization to `ProjectApiResource`