### PR TITLE
b/330263705 Use name binding for JAX-RS request filters

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/web/IapRequestFilter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/IapRequestFilter.java
@@ -19,13 +19,17 @@
 // under the License.
 //
 
-package com.google.solutions.jitaccess.web.iap;
+package com.google.solutions.jitaccess.web;
 
 import com.google.auth.oauth2.TokenVerifier;
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.core.auth.UserEmail;
 import com.google.solutions.jitaccess.web.LogAdapter;
+import com.google.solutions.jitaccess.web.RequireIapPrincipal;
 import com.google.solutions.jitaccess.web.RuntimeEnvironment;
+import com.google.solutions.jitaccess.web.iap.DeviceInfo;
+import com.google.solutions.jitaccess.web.iap.IapAssertion;
+import com.google.solutions.jitaccess.web.iap.IapPrincipal;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
@@ -46,6 +50,7 @@ import java.security.Principal;
 @Dependent
 @Provider
 @Priority(Priorities.AUTHENTICATION)
+@RequireIapPrincipal
 public class IapRequestFilter implements ContainerRequestFilter {
   private static final String EVENT_AUTHENTICATE = "iap.authenticate";
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RequireIapPrincipal.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RequireIapPrincipal.java
@@ -29,11 +29,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicate that a resource class requires that requests
- * contain an XSRF header.
+ * Indicate that a resource class requires requests to
+ * contain a valid IAP assertion.
  */
 @NameBinding
 @Target({ ElementType.METHOD, ElementType.TYPE})
 @Retention(value = RetentionPolicy.RUNTIME)
-public @interface RequiresXsrfHeader {
+public @interface RequireIapPrincipal {
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RequireXsrfHeader.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RequireXsrfHeader.java
@@ -1,0 +1,39 @@
+//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.google.solutions.jitaccess.web;
+
+import jakarta.ws.rs.NameBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicate that a resource class requires requests to
+ * contain an XSRF header.
+ */
+@NameBinding
+@Target({ ElementType.METHOD, ElementType.TYPE})
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface RequireXsrfHeader {
+}

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RequiresXsrfHeader.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RequiresXsrfHeader.java
@@ -1,0 +1,39 @@
+//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.google.solutions.jitaccess.web;
+
+import jakarta.ws.rs.NameBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicate that a resource class requires that requests
+ * contain an XSRF header.
+ */
+@NameBinding
+@Target({ ElementType.METHOD, ElementType.TYPE})
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface RequiresXsrfHeader {
+}

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/XsrfRequestFilter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/XsrfRequestFilter.java
@@ -38,7 +38,7 @@ import org.jetbrains.annotations.NotNull;
 @Dependent
 @Provider
 @Priority(Priorities.AUTHENTICATION - 200)
-@RequiresXsrfHeader
+@RequireXsrfHeader
 public class XsrfRequestFilter implements ContainerRequestFilter {
 
   public static final String XSRF_HEADER_NAME = "X-JITACCESS";

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/XsrfRequestFilter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/XsrfRequestFilter.java
@@ -38,6 +38,7 @@ import org.jetbrains.annotations.NotNull;
 @Dependent
 @Provider
 @Priority(Priorities.AUTHENTICATION - 200)
+@RequiresXsrfHeader
 public class XsrfRequestFilter implements ContainerRequestFilter {
 
   public static final String XSRF_HEADER_NAME = "X-JITACCESS";

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/AbstractApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/AbstractApiResource.java
@@ -21,11 +21,9 @@
 
 package com.google.solutions.jitaccess.web.rest;
 
-import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.AccessException;
 import com.google.solutions.jitaccess.core.ResourceNotFoundException;
 import com.google.solutions.jitaccess.core.catalog.ResourceId;
-import com.google.solutions.jitaccess.web.RequiresXsrfHeader;
 import com.google.solutions.jitaccess.web.iap.IapPrincipal;
 import com.google.solutions.jitaccess.web.actions.*;
 import jakarta.ws.rs.*;

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/AbstractApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/AbstractApiResource.java
@@ -25,6 +25,7 @@ import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.AccessException;
 import com.google.solutions.jitaccess.core.ResourceNotFoundException;
 import com.google.solutions.jitaccess.core.catalog.ResourceId;
+import com.google.solutions.jitaccess.web.RequiresXsrfHeader;
 import com.google.solutions.jitaccess.web.iap.IapPrincipal;
 import com.google.solutions.jitaccess.web.actions.*;
 import jakarta.ws.rs.*;

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
@@ -7,7 +7,8 @@ import com.google.solutions.jitaccess.core.catalog.project.MpaProjectRoleCatalog
 import com.google.solutions.jitaccess.core.catalog.project.ProjectRoleActivator;
 import com.google.solutions.jitaccess.core.notifications.NotificationService;
 import com.google.solutions.jitaccess.web.LogAdapter;
-import com.google.solutions.jitaccess.web.RequiresXsrfHeader;
+import com.google.solutions.jitaccess.web.RequireIapPrincipal;
+import com.google.solutions.jitaccess.web.RequireXsrfHeader;
 import com.google.solutions.jitaccess.web.RuntimeEnvironment;
 import com.google.solutions.jitaccess.web.actions.*;
 import jakarta.enterprise.context.Dependent;
@@ -20,7 +21,8 @@ import jakarta.ws.rs.Path;
  */
 @Dependent
 @Path("/api/")
-@RequiresXsrfHeader
+@RequireXsrfHeader
+@RequireIapPrincipal
 public class ProjectApiResource extends AbstractApiResource<ProjectId> {
 
   @Inject

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
@@ -7,6 +7,7 @@ import com.google.solutions.jitaccess.core.catalog.project.MpaProjectRoleCatalog
 import com.google.solutions.jitaccess.core.catalog.project.ProjectRoleActivator;
 import com.google.solutions.jitaccess.core.notifications.NotificationService;
 import com.google.solutions.jitaccess.web.LogAdapter;
+import com.google.solutions.jitaccess.web.RequiresXsrfHeader;
 import com.google.solutions.jitaccess.web.RuntimeEnvironment;
 import com.google.solutions.jitaccess.web.actions.*;
 import jakarta.enterprise.context.Dependent;
@@ -19,6 +20,7 @@ import jakarta.ws.rs.Path;
  */
 @Dependent
 @Path("/api/")
+@RequiresXsrfHeader
 public class ProjectApiResource extends AbstractApiResource<ProjectId> {
 
   @Inject

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestIapRequestFilter.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestIapRequestFilter.java
@@ -19,10 +19,8 @@
 // under the License.
 //
 
-package com.google.solutions.jitaccess.web.iap;
+package com.google.solutions.jitaccess.web;
 
-import com.google.solutions.jitaccess.web.LogAdapter;
-import com.google.solutions.jitaccess.web.RuntimeEnvironment;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Use name-bound filters to perform IAP- and XSRF checks so that the checks can be disabled for individual resources.