### PR TITLE
b/330263705 Add liveness, readiness endpoints

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/clients/Diagnosable.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/clients/Diagnosable.java
@@ -21,9 +21,11 @@
 
 package com.google.solutions.jitaccess.core.clients;
 
+import java.util.Collection;
+
 public interface Diagnosable {
   /**
    * Perform a self-check.
    */
-  DiagnosticsResult diagnose();
+  Collection<DiagnosticsResult> diagnose();
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/clients/Diagnosable.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/clients/Diagnosable.java
@@ -22,5 +22,8 @@
 package com.google.solutions.jitaccess.core.clients;
 
 public interface Diagnosable {
+  /**
+   * Perform a self-check.
+   */
   DiagnosticsResult diagnose();
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/clients/Diagnosable.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/clients/Diagnosable.java
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -19,18 +19,8 @@
 // under the License.
 //
 
-package com.google.solutions.jitaccess.web;
+package com.google.solutions.jitaccess.core.clients;
 
-public class LogEvents {
-  public static final String API_LIST_PROJECTS = "api.listProjects";
-  public static final String API_LIST_ROLES = "api.listEligibleRoles";
-  public static final String API_LIST_PEERS = "api.listPeers";
-  public static final String API_ACTIVATE_ROLE = "api.activateRole";
-  public static final String API_REQUEST_ROLE = "api.requestRole";
-  public static final String API_GET_REQUEST = "api.getActivationRequest";
-  public static final String API_HEALTH = "api.health";
-  public static final String RUNTIME_STARTUP = "runtime.startup";
-
-  private LogEvents() {
-  }
+public interface Diagnosable {
+  DiagnosticsResult diagnose();
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/clients/DiagnosticsResult.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/clients/DiagnosticsResult.java
@@ -21,9 +21,29 @@
 
 package com.google.solutions.jitaccess.core.clients;
 
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @param name name of the check that was performed
+ * @param successful result of the check
+ * @param details error message in case the check failed
+ */
 public record DiagnosticsResult(
+  @NotNull String name,
   boolean successful,
   String details
 ) {
-  public static final DiagnosticsResult SUCCESS = new DiagnosticsResult(true, null);
+  public DiagnosticsResult(@NotNull String name) {
+    this(name, true, null);
+  }
+
+  @Override
+  public String toString() {
+    if (this.successful) {
+      return String.format("%s: OK", this.name);
+    }
+    else {
+      return String.format("%s: %s", this.name, this.details);
+    }
+  }
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/clients/DiagnosticsResult.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/clients/DiagnosticsResult.java
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -19,18 +19,10 @@
 // under the License.
 //
 
-package com.google.solutions.jitaccess.web;
+package com.google.solutions.jitaccess.core.clients;
 
-public class LogEvents {
-  public static final String API_LIST_PROJECTS = "api.listProjects";
-  public static final String API_LIST_ROLES = "api.listEligibleRoles";
-  public static final String API_LIST_PEERS = "api.listPeers";
-  public static final String API_ACTIVATE_ROLE = "api.activateRole";
-  public static final String API_REQUEST_ROLE = "api.requestRole";
-  public static final String API_GET_REQUEST = "api.getActivationRequest";
-  public static final String API_HEALTH = "api.health";
-  public static final String RUNTIME_STARTUP = "runtime.startup";
-
-  private LogEvents() {
-  }
+public record DiagnosticsResult(
+  boolean successful,
+  String details
+) {
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/clients/DiagnosticsResult.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/clients/DiagnosticsResult.java
@@ -25,4 +25,5 @@ public record DiagnosticsResult(
   boolean successful,
   String details
 ) {
+  public static final DiagnosticsResult SUCCESS = new DiagnosticsResult(true, null);
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/LogEvents.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/LogEvents.java
@@ -28,7 +28,7 @@ public class LogEvents {
   public static final String API_ACTIVATE_ROLE = "api.activateRole";
   public static final String API_REQUEST_ROLE = "api.requestRole";
   public static final String API_GET_REQUEST = "api.getActivationRequest";
-  public static final String API_HEALTH = "api.health";
+  public static final String API_HEALTH = "api.checkHealth";
   public static final String RUNTIME_STARTUP = "runtime.startup";
 
   private LogEvents() {

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
@@ -50,6 +50,8 @@ import org.jetbrains.annotations.NotNull;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.regex.Pattern;
 
@@ -426,16 +428,21 @@ public class RuntimeEnvironment {
   @Produces
   @Singleton
   public @NotNull Diagnosable verifyDevModeIsDisabled() {
+    final String name = "DevModeIsDisabled";
     return new Diagnosable() {
       @Override
-      public DiagnosticsResult diagnose() {
+      public Collection<DiagnosticsResult> diagnose() {
         if (!isDebugModeEnabled()) {
-          return DiagnosticsResult.SUCCESS;
+          return List.of(new DiagnosticsResult(name));
         }
         else {
-          return new DiagnosticsResult(false, "Application is running in development mode");
+          return List.of(
+            new DiagnosticsResult(
+              name,
+              false,
+              "Application is running in development mode"));
         }
       }
-    }
+    };
   }
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
@@ -422,4 +422,20 @@ public class RuntimeEnvironment {
           new PolicyAnalyzerRepository.Options(this.configuration.scope.getValue()));
     }
   }
+
+  @Produces
+  @Singleton
+  public @NotNull Diagnosable verifyDevModeIsDisabled() {
+    return new Diagnosable() {
+      @Override
+      public DiagnosticsResult diagnose() {
+        if (!isDebugModeEnabled()) {
+          return DiagnosticsResult.SUCCESS;
+        }
+        else {
+          return new DiagnosticsResult(false, "Application is running in development mode");
+        }
+      }
+    }
+  }
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/HealthResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/HealthResource.java
@@ -1,0 +1,140 @@
+//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.google.solutions.jitaccess.web.rest;
+
+import com.google.solutions.jitaccess.core.ThrowingCompletableFuture;
+import com.google.solutions.jitaccess.core.clients.Diagnosable;
+import com.google.solutions.jitaccess.core.clients.DiagnosticsResult;
+import com.google.solutions.jitaccess.web.LogAdapter;
+import com.google.solutions.jitaccess.web.LogEvents;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+/**
+ * REST API controller for health checks.
+ */
+@Dependent
+@Path("/health")
+public class HealthResource {
+
+  // TODO: exclude from filters
+  // TODO: implement Diagnosable
+
+  @Inject
+  Executor executor;
+
+  @Inject
+  Instance<Diagnosable> diagnosables;
+
+  @Inject
+  LogAdapter logAdapter;
+
+  /**
+   * Check if the application is alive.
+   */
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("alive")
+  public @NotNull ResponseEntity checkLiveness() {
+    //
+    // The fact that this class received a request is sufficient
+    // indication that the application initialized successfully
+    // and that Quarkus is working.
+    //
+    // Restarting the application would serve no purpose at this
+    // point.
+    //
+    return new ResponseEntity(true, Map.of());
+  }
+
+  /**
+   * Check if the application is ready to receive requests.
+   */
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("ready")
+  public @NotNull ResponseEntity checkReadiness() throws ExecutionException, InterruptedException {
+    //
+    // Diagnose all services that support self-diagnosis.
+    //
+    var diagnosticsFuturesByService = this.diagnosables
+      .stream()
+      .map(d -> new AbstractMap.SimpleEntry<>(
+        d,
+        ThrowingCompletableFuture.submit(() -> d.diagnose(), this.executor)))
+      .toList();
+
+    //
+    // Consolidate results. The response only contains a summary,
+    // any errors only go to the log.
+    //
+    var results = new HashMap<Diagnosable, DiagnosticsResult>();
+    for (var future : diagnosticsFuturesByService) {
+      var result = future.getValue().get();
+      results.put(future.getKey(), result);
+
+      if (!result.successful()) {
+        this.logAdapter
+          .newWarningEntry(
+            LogEvents.API_HEALTH,
+            String.format(
+              "%s is in an unhealthy state: %s",
+              future.getKey().getClass().getSimpleName(),
+              result.details()))
+          .write();
+      }
+    }
+
+    var resultsByService = results
+      .entrySet()
+      .stream()
+      .collect(Collectors.toMap(
+        e -> e.getKey().getClass().getSimpleName(),
+        e -> e.getValue().successful()));
+
+    return new ResponseEntity(
+      resultsByService.values().stream().allMatch(v -> v), // AND-combine results.
+      resultsByService);
+  }
+
+  /**
+   * @param healthy overall status
+   * @param details status of individual services
+   */
+  public record ResponseEntity(
+    boolean healthy,
+    Map<String, Boolean> details
+  ) {}
+}

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/HealthResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/HealthResource.java
@@ -23,7 +23,6 @@ package com.google.solutions.jitaccess.web.rest;
 
 import com.google.solutions.jitaccess.core.ThrowingCompletableFuture;
 import com.google.solutions.jitaccess.core.clients.Diagnosable;
-import com.google.solutions.jitaccess.core.clients.DiagnosticsResult;
 import com.google.solutions.jitaccess.web.LogAdapter;
 import com.google.solutions.jitaccess.web.LogEvents;
 import jakarta.enterprise.context.Dependent;
@@ -36,8 +35,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.AbstractMap;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/HealthResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/HealthResource.java
@@ -44,6 +44,8 @@ import java.util.stream.Collectors;
 
 /**
  * REST API controller for health checks.
+ *
+ * This controller allows anonymous requests.
  */
 @Dependent
 @Path("/health")

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/HealthResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/HealthResource.java
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
 @Path("/health")
 public class HealthResource {
 
-  // TODO: exclude from filters
+  // TODO: exclude from filters (@RequireXsrfHeader, @RequireIapAssertion)
   // TODO: implement Diagnosable
 
   @Inject

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProjectApiResource.java
@@ -1,3 +1,24 @@
+//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
 package com.google.solutions.jitaccess.web.rest;
 
 import com.google.solutions.jitaccess.core.catalog.JustificationPolicy;

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/MockitoUtils.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/MockitoUtils.java
@@ -19,7 +19,7 @@
 // under the License.
 //
 
-package com.google.solutions.jitaccess.web.actions;
+package com.google.solutions.jitaccess.web;
 
 import jakarta.enterprise.inject.Instance;
 import org.mockito.Mockito;
@@ -28,11 +28,11 @@ import java.util.List;
 
 import static org.mockito.Mockito.when;
 
-class MockitoUtils {
+public class MockitoUtils {
   /**
    * Create an Instance for a given object.
    */
-  static <T> Instance<T> toCdiInstance(T obj) {
+  public static <T> Instance<T> toCdiInstance(T obj) {
     var instance = Mockito.mock(Instance.class);
     when(instance.stream()).thenReturn(List.of(obj).stream());
     when(instance.iterator()).thenReturn(List.of(obj).iterator());

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestApproveActivationRequestAction.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestApproveActivationRequestAction.java
@@ -32,6 +32,7 @@ import com.google.solutions.jitaccess.core.catalog.project.ProjectRoleActivator;
 import com.google.solutions.jitaccess.core.clients.ResourceManagerClient;
 import com.google.solutions.jitaccess.core.notifications.NotificationService;
 import com.google.solutions.jitaccess.web.LogAdapter;
+import com.google.solutions.jitaccess.web.MockitoUtils;
 import com.google.solutions.jitaccess.web.RuntimeEnvironment;
 import com.google.solutions.jitaccess.web.TokenObfuscator;
 import jakarta.enterprise.inject.Instance;

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestRequestActivationAction.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestRequestActivationAction.java
@@ -32,6 +32,7 @@ import com.google.solutions.jitaccess.core.catalog.project.MpaProjectRoleCatalog
 import com.google.solutions.jitaccess.core.catalog.project.ProjectRoleActivator;
 import com.google.solutions.jitaccess.core.clients.ResourceManagerClient;
 import com.google.solutions.jitaccess.web.LogAdapter;
+import com.google.solutions.jitaccess.web.MockitoUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestRequestAndSelfApproveAction.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestRequestAndSelfApproveAction.java
@@ -31,6 +31,7 @@ import com.google.solutions.jitaccess.core.catalog.ProjectId;
 import com.google.solutions.jitaccess.core.catalog.project.ProjectRole;
 import com.google.solutions.jitaccess.core.catalog.project.ProjectRoleActivator;
 import com.google.solutions.jitaccess.web.LogAdapter;
+import com.google.solutions.jitaccess.web.MockitoUtils;
 import com.google.solutions.jitaccess.web.RuntimeEnvironment;
 import jakarta.enterprise.inject.Instance;
 import org.junit.jupiter.api.Test;

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestHealthResource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestHealthResource.java
@@ -1,0 +1,105 @@
+//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.google.solutions.jitaccess.web.rest;
+
+import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.clients.DiagnosticsResult;
+import com.google.solutions.jitaccess.web.LogAdapter;
+import com.google.solutions.jitaccess.web.RestDispatcher;
+import com.google.solutions.jitaccess.web.MockitoUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestHealthResource {
+  private static final UserEmail SAMPLE_USER = new UserEmail("user-1@example.com");
+
+  //---------------------------------------------------------------------------
+  // /health/alive
+  //---------------------------------------------------------------------------
+
+  @Test
+  public void checkLivenessReturns200() throws Exception {
+    var response = new RestDispatcher<>(new HealthResource(), SAMPLE_USER)
+      .get("/health/alive", HealthResource.ResponseEntity.class);
+
+    assertEquals(200, response.getStatus());
+    assertTrue(response.getBody().healthy());
+  }
+
+  //---------------------------------------------------------------------------
+  // /health/ready
+  //---------------------------------------------------------------------------
+
+  @Test
+  public void whenChecksSucceed_thenCheckReadinessReturns200() throws Exception {
+    var resource = new HealthResource();
+    resource.logAdapter = new LogAdapter();
+    resource.executor = new Executor() {
+      @Override
+      public void execute(@NotNull Runnable command) {
+        command.run();
+      }
+    };
+
+    resource.diagnosables = MockitoUtils.toCdiInstance(
+      () -> List.of(new DiagnosticsResult("Sample-1")));
+
+    var response = new RestDispatcher<>(resource, SAMPLE_USER)
+      .get("/health/ready", HealthResource.ResponseEntity.class);
+
+    assertEquals(200, response.getStatus());
+    assertTrue(response.getBody().healthy());
+    assertEquals(Map.of("Sample-1", true), response.getBody().details());
+  }
+
+  @Test
+  public void whenAnyCheckFails_thenCheckReadinessReturns503() throws Exception {
+    var resource = new HealthResource();
+    resource.logAdapter = new LogAdapter();
+    resource.executor = new Executor() {
+      @Override
+      public void execute(@NotNull Runnable command) {
+        command.run();
+      }
+    };
+
+    resource.diagnosables = MockitoUtils.toCdiInstance(
+      () -> List.of(
+        new DiagnosticsResult("Sample-1"),
+        new DiagnosticsResult("Sample-2", false, "error")));
+
+    var response = new RestDispatcher<>(resource, SAMPLE_USER)
+      .get("/health/ready", HealthResource.ResponseEntity.class);
+
+    assertEquals(503, response.getStatus());
+    assertFalse(response.getBody().healthy());
+    assertEquals(
+      Map.of("Sample-1", true, "Sample-2", false),
+      response.getBody().details());
+  }
+}


### PR DESCRIPTION
Add two endpoints:

* `/health/alive`: Simple liveness check indicating that the application has started up
* `/health/ready`: Health check that performd additional diagnostics checks

For now, the only diagnostics check performed by `/health/ready` is to check whether
development mode is off, but we could add additional checks later.

Implements #320