### PR TITLE
b/330263707 Rename to UserId, GroupId

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/auth/AccessControlList.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/auth/AccessControlList.java
@@ -30,7 +30,7 @@ import java.util.Set;
  * @param allowedPrincipals allowed principals
  */
 public record AccessControlList(
-  @NotNull Set<PrincipalIdentifier> allowedPrincipals
+  @NotNull Set<PrincipalId> allowedPrincipals
 ){
   /**
    * Check whether a subject is allowed access.

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/auth/GroupId.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/auth/GroupId.java
@@ -28,13 +28,16 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 /**
- * Email address of a group.
+ * Principal identifier for a group.
+ *
+ * NB. The ID looks like an email address, but it might not
+ *     be a route-able email address.
  */
-public class GroupEmail implements Comparable<GroupEmail>, PrincipalIdentifier {
+public class GroupId implements Comparable<GroupId>, PrincipalId {
   public static final String TYPE = "group";
   public final @NotNull String email;
 
-  public GroupEmail(@NotNull String email) {
+  public GroupId(@NotNull String email) {
     Preconditions.checkNotNull(email, "email");
     this.email = email;
   }
@@ -58,8 +61,8 @@ public class GroupEmail implements Comparable<GroupEmail>, PrincipalIdentifier {
       return false;
     }
 
-    GroupEmail GroupEmail = (GroupEmail) o;
-    return email.equals(GroupEmail.email);
+    GroupId groupId = (GroupId) o;
+    return email.equals(groupId.email);
   }
 
   @Override
@@ -68,7 +71,7 @@ public class GroupEmail implements Comparable<GroupEmail>, PrincipalIdentifier {
   }
 
   @Override
-  public int compareTo(@NotNull GroupEmail o) {
+  public int compareTo(@NotNull GroupId o) {
     return this.email.compareTo(o.email);
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/auth/PrincipalId.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/auth/PrincipalId.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Identifier for a principal such as a user or group.
  */
-public interface PrincipalIdentifier {
+public interface PrincipalId {
   /**
    * Type of principal, for example user, serviceAccount, group.
    */

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/auth/Subject.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/auth/Subject.java
@@ -32,10 +32,10 @@ public interface Subject {
   /**
    * @return Primary id.
    */
-  @NotNull PrincipalIdentifier id();
+  @NotNull PrincipalId id();
 
   /**
    * @return full set of principals, including groups.
    */
-  @NotNull Set<PrincipalIdentifier> principals();
+  @NotNull Set<PrincipalId> principals();
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/auth/UserId.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/auth/UserId.java
@@ -28,14 +28,17 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 /**
- * Primary email address of a user.
+ * Principal identifier for a user.
+ *
+ * NB. The ID looks like an email address, but it might not
+ *     be a route-able email address.
  */
-public class UserEmail implements Comparable<UserEmail>, PrincipalIdentifier {
+public class UserId implements Comparable<UserId>, PrincipalId {
   public static final String TYPE = "user";
 
   public final @NotNull String email;
 
-  public UserEmail(@NotNull String email) {
+  public UserId(@NotNull String email) {
     Preconditions.checkNotNull(email, "email");
     this.email = email;
   }
@@ -59,8 +62,8 @@ public class UserEmail implements Comparable<UserEmail>, PrincipalIdentifier {
       return false;
     }
 
-    UserEmail userEmail = (UserEmail) o;
-    return email.equals(userEmail.email);
+    UserId userId = (UserId) o;
+    return email.equals(userId.email);
   }
 
   @Override
@@ -69,7 +72,7 @@ public class UserEmail implements Comparable<UserEmail>, PrincipalIdentifier {
   }
 
   @Override
-  public int compareTo(@NotNull UserEmail o) {
+  public int compareTo(@NotNull UserId o) {
     return this.email.compareTo(o.email);
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/ActivationRequest.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/ActivationRequest.java
@@ -22,7 +22,7 @@
 package com.google.solutions.jitaccess.core.catalog;
 
 import com.google.common.base.Preconditions;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
@@ -38,13 +38,13 @@ public abstract class ActivationRequest<TEntitlementId extends EntitlementId> {
   private final @NotNull ActivationId id;
   private final @NotNull Instant startTime;
   private final @NotNull Duration duration;
-  private final @NotNull UserEmail requestingUser;
+  private final @NotNull UserId requestingUser;
   private final @NotNull Set<TEntitlementId> entitlements;
   private final @NotNull String justification;
 
   protected ActivationRequest(
     @NotNull ActivationId id,
-    @NotNull UserEmail requestingUser,
+    @NotNull UserId requestingUser,
     @NotNull Set<TEntitlementId> entitlements,
     @NotNull String justification,
     @NotNull Instant startTime,
@@ -105,7 +105,7 @@ public abstract class ActivationRequest<TEntitlementId extends EntitlementId> {
   /**
    * @return user that requested access.
    */
-  public @NotNull UserEmail requestingUser() {
+  public @NotNull UserId requestingUser() {
     return this.requestingUser;
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/Catalog.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/Catalog.java
@@ -22,7 +22,7 @@
 package com.google.solutions.jitaccess.core.catalog;
 
 import com.google.solutions.jitaccess.core.AccessException;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -44,7 +44,7 @@ public interface Catalog<
    * with the catalog.
    */
   @NotNull TUserContext createContext(
-    @NotNull UserEmail user
+    @NotNull UserId user
   ) throws AccessException, IOException;
 
   /**
@@ -73,7 +73,7 @@ public interface Catalog<
   /**
    * List available reviewers for (MPA-) activating an entitlement.
    */
-  SortedSet<UserEmail> listReviewers(
+  SortedSet<UserId> listReviewers(
     @NotNull TUserContext userContext,
     @NotNull TEntitlementId entitlement
   ) throws AccessException, IOException;

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/CatalogUserContext.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/CatalogUserContext.java
@@ -21,7 +21,7 @@
 
 package com.google.solutions.jitaccess.core.catalog;
 
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -32,5 +32,5 @@ public interface CatalogUserContext {
   /**
    * @return ID of the user.
    */
-  @NotNull UserEmail user();
+  @NotNull UserId user();
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/EntitlementActivator.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/EntitlementActivator.java
@@ -23,7 +23,7 @@ package com.google.solutions.jitaccess.core.catalog;
 
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.core.*;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -96,7 +96,7 @@ public abstract class EntitlementActivator<
   public @NotNull MpaActivationRequest<TEntitlementId> createMpaRequest(
     @NotNull TUserContext requestingUserContext,
     @NotNull Set<TEntitlementId> entitlements,
-    @NotNull Set<UserEmail> reviewers,
+    @NotNull Set<UserId> reviewers,
     @NotNull String justification,
     @NotNull Instant startTime,
     @NotNull Duration duration
@@ -205,7 +205,7 @@ public abstract class EntitlementActivator<
    * Apply a request.
    */
   protected abstract Activation provisionAccess(
-    @NotNull UserEmail approvingUser,
+    @NotNull UserId approvingUser,
     @NotNull MpaActivationRequest<TEntitlementId> request
   ) throws AccessException, AlreadyExistsException, IOException;
 
@@ -223,7 +223,7 @@ public abstract class EntitlementActivator<
     extends JitActivationRequest<TEntitlementId> {
     public JitRequest(
       @NotNull ActivationId id,
-      @NotNull UserEmail requestingUser,
+      @NotNull UserId requestingUser,
       @NotNull Set<TEntitlementId> entitlements,
       @NotNull String justification,
       @NotNull Instant startTime,
@@ -237,9 +237,9 @@ public abstract class EntitlementActivator<
     extends MpaActivationRequest<TEntitlementId> {
     public MpaRequest(
       @NotNull ActivationId id,
-      @NotNull UserEmail requestingUser,
+      @NotNull UserId requestingUser,
       @NotNull Set<TEntitlementId> entitlements,
-      @NotNull Set<UserEmail> reviewers,
+      @NotNull Set<UserId> reviewers,
       @NotNull String justification,
       @NotNull Instant startTime,
       @NotNull Duration duration

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/JitActivationRequest.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/JitActivationRequest.java
@@ -21,7 +21,7 @@
 
 package com.google.solutions.jitaccess.core.catalog;
 
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
@@ -35,7 +35,7 @@ public abstract class JitActivationRequest<TEntitlementId extends EntitlementId>
   extends ActivationRequest<TEntitlementId> {
   protected JitActivationRequest(
     @NotNull ActivationId id,
-    @NotNull UserEmail requestingUser,
+    @NotNull UserId requestingUser,
     @NotNull Set<TEntitlementId> entitlements,
     @NotNull String justification,
     @NotNull Instant startTime,

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/JustificationPolicy.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/JustificationPolicy.java
@@ -21,7 +21,7 @@
 
 package com.google.solutions.jitaccess.core.catalog;
 
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -33,7 +33,7 @@ public interface JustificationPolicy {
    * Check that a justification meets criteria.
    */
   void checkJustification(
-    @NotNull UserEmail user,
+    @NotNull UserId user,
     @Nullable String justification
   ) throws InvalidJustificationException;
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/MpaActivationRequest.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/MpaActivationRequest.java
@@ -22,7 +22,7 @@
 package com.google.solutions.jitaccess.core.catalog;
 
 import com.google.common.base.Preconditions;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
@@ -35,13 +35,13 @@ import java.util.Set;
  */
 public abstract class MpaActivationRequest<TEntitlementId extends EntitlementId>
   extends ActivationRequest<TEntitlementId> {
-  private final @NotNull Collection<UserEmail> reviewers;
+  private final @NotNull Collection<UserId> reviewers;
 
   protected MpaActivationRequest(
     @NotNull ActivationId id,
-    @NotNull UserEmail requestingUser,
+    @NotNull UserId requestingUser,
     @NotNull Set<TEntitlementId> entitlements,
-    @NotNull Set<UserEmail> reviewers,
+    @NotNull Set<UserId> reviewers,
     @NotNull String justification,
     @NotNull Instant startTime,
     @NotNull Duration duration) {
@@ -58,7 +58,7 @@ public abstract class MpaActivationRequest<TEntitlementId extends EntitlementId>
     this.reviewers = reviewers;
   }
 
-  public @NotNull Collection<UserEmail> reviewers() {
+  public @NotNull Collection<UserId> reviewers() {
     return this.reviewers;
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/RegexJustificationPolicy.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/RegexJustificationPolicy.java
@@ -23,7 +23,7 @@ package com.google.solutions.jitaccess.core.catalog;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import jakarta.inject.Singleton;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,7 +44,7 @@ public class RegexJustificationPolicy implements JustificationPolicy {
 
   @Override
   public void checkJustification(
-    @NotNull UserEmail user,
+    @NotNull UserId user,
     @Nullable String justification
   ) throws InvalidJustificationException {
     if (

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/TokenSigner.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/TokenSigner.java
@@ -24,7 +24,7 @@ package com.google.solutions.jitaccess.core.catalog;
 import com.google.auth.oauth2.TokenVerifier;
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.core.AccessException;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.clients.IamCredentialsClient;
 import jakarta.inject.Singleton;
 import org.jetbrains.annotations.NotNull;
@@ -131,7 +131,7 @@ public class TokenSigner {
   }
 
   public record Options(
-    @NotNull UserEmail serviceAccount,
+    @NotNull UserId serviceAccount,
     @NotNull Duration tokenValidity
   ) {
     public Options {

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/AssetInventoryRepository.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/AssetInventoryRepository.java
@@ -27,7 +27,7 @@ import com.google.api.services.directory.model.Member;
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.cel.TemporaryIamCondition;
 import com.google.solutions.jitaccess.core.*;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.*;
 import com.google.solutions.jitaccess.core.clients.AssetInventoryClient;
 import com.google.solutions.jitaccess.core.clients.DirectoryGroupsClient;
@@ -75,7 +75,7 @@ public class AssetInventoryRepository extends ProjectRoleRepository {
   }
 
   @NotNull List<Binding> findProjectBindings(
-    @NotNull UserEmail user,
+    @NotNull UserId user,
     ProjectId projectId
   ) throws AccessException, IOException {
     //
@@ -115,7 +115,7 @@ public class AssetInventoryRepository extends ProjectRoleRepository {
 
   @Override
   public @NotNull SortedSet<ProjectId> findProjectsWithEntitlements(
-    @NotNull UserEmail user
+    @NotNull UserId user
   ) {
     //
     // Not supported.
@@ -126,7 +126,7 @@ public class AssetInventoryRepository extends ProjectRoleRepository {
 
   @Override
   public @NotNull EntitlementSet<ProjectRole> findEntitlements(
-    @NotNull UserEmail user,
+    @NotNull UserId user,
     @NotNull ProjectId projectId,
     @NotNull EnumSet<ActivationType> typesToInclude
   ) throws AccessException, IOException {
@@ -221,7 +221,7 @@ public class AssetInventoryRepository extends ProjectRoleRepository {
   }
 
   @Override
-  public @NotNull Set<UserEmail> findEntitlementHolders(
+  public @NotNull Set<UserId> findEntitlementHolders(
     @NotNull ProjectRole roleBinding,
     @NotNull ActivationType activationType
   ) throws AccessException, IOException {
@@ -251,7 +251,7 @@ public class AssetInventoryRepository extends ProjectRoleRepository {
       .filter(p -> p.startsWith(USER_PREFIX))
       .map(p -> p.substring(USER_PREFIX.length()))
       .distinct()
-      .map(email -> new UserEmail(email))
+      .map(email -> new UserId(email))
       .collect(Collectors.toSet());
 
     //
@@ -282,7 +282,7 @@ public class AssetInventoryRepository extends ProjectRoleRepository {
     for (var listMembersFuture : listMembersFutures) {
       var members = ThrowingCompletableFuture.awaitAndRethrow(listMembersFuture)
         .stream()
-        .map(m -> new UserEmail(m.getEmail())).toList();
+        .map(m -> new UserId(m.getEmail())).toList();
       allMembers.addAll(members);
     }
 
@@ -297,7 +297,7 @@ public class AssetInventoryRepository extends ProjectRoleRepository {
     private final @NotNull Set<String> principalIdentifiers;
 
     public PrincipalSet(
-      @NotNull UserEmail user,
+      @NotNull UserId user,
       @NotNull Collection<Group> groups
     ) {
       this.principalIdentifiers = groups

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/MpaProjectRoleCatalog.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/MpaProjectRoleCatalog.java
@@ -26,7 +26,7 @@ import com.google.common.base.Strings;
 import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.AccessException;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.*;
 import com.google.solutions.jitaccess.core.clients.ResourceManagerClient;
 import jakarta.inject.Singleton;
@@ -96,7 +96,7 @@ public class MpaProjectRoleCatalog implements Catalog<
   }
 
   void verifyUserCanActivateEntitlements(
-    @NotNull UserEmail user,
+    @NotNull UserId user,
     @NotNull ProjectId projectId,
     @NotNull ActivationType activationType,
     @NotNull Collection<ProjectRole> entitlements
@@ -142,7 +142,7 @@ public class MpaProjectRoleCatalog implements Catalog<
 
   @Override
   public @NotNull UserContext createContext(
-    @NotNull UserEmail user
+    @NotNull UserId user
   ) {
     return new UserContext(user);
   }
@@ -183,7 +183,7 @@ public class MpaProjectRoleCatalog implements Catalog<
   }
 
   @Override
-  public @NotNull SortedSet<UserEmail> listReviewers(
+  public @NotNull SortedSet<UserId> listReviewers(
     @NotNull UserContext userContext,
     @NotNull ProjectRole entitlement
   ) throws AccessException, IOException {
@@ -259,7 +259,7 @@ public class MpaProjectRoleCatalog implements Catalog<
   // -------------------------------------------------------------------------
 
   public record UserContext(
-    @NotNull UserEmail user
+    @NotNull UserId user
   ) implements CatalogUserContext {
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/PolicyAnalyzerRepository.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/PolicyAnalyzerRepository.java
@@ -29,7 +29,7 @@ import com.google.solutions.jitaccess.cel.TemporaryIamCondition;
 import com.google.solutions.jitaccess.core.AccessException;
 import com.google.solutions.jitaccess.core.catalog.*;
 import com.google.solutions.jitaccess.core.RoleBinding;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.clients.PolicyAnalyzerClient;
 import org.jetbrains.annotations.NotNull;
 
@@ -109,7 +109,7 @@ public class PolicyAnalyzerRepository extends ProjectRoleRepository {
 
   @Override
   public @NotNull SortedSet<ProjectId> findProjectsWithEntitlements(
-    @NotNull UserEmail user
+    @NotNull UserId user
   ) throws AccessException, IOException {
 
     Preconditions.checkNotNull(user, "user");
@@ -154,7 +154,7 @@ public class PolicyAnalyzerRepository extends ProjectRoleRepository {
 
   @Override
   public @NotNull EntitlementSet<ProjectRole> findEntitlements(
-    @NotNull UserEmail user,
+    @NotNull UserId user,
     @NotNull ProjectId projectId,
     @NotNull EnumSet<ActivationType> typesToInclude
   ) throws AccessException, IOException {
@@ -275,7 +275,7 @@ public class PolicyAnalyzerRepository extends ProjectRoleRepository {
   }
 
   @Override
-  public @NotNull Set<UserEmail> findEntitlementHolders(
+  public @NotNull Set<UserId> findEntitlementHolders(
     @NotNull ProjectRole roleBinding,
     @NotNull ActivationType activationType
   ) throws AccessException, IOException {
@@ -299,7 +299,7 @@ public class PolicyAnalyzerRepository extends ProjectRoleRepository {
       .filter(result -> result.getIdentityList() != null)
       .flatMap(result -> result.getIdentityList().getIdentities().stream()
         .filter(id -> id.getName().startsWith("user:"))
-        .map(id -> new UserEmail(id.getName().substring("user:".length()))))
+        .map(id -> new UserId(id.getName().substring("user:".length()))))
 
       .collect(Collectors.toCollection(TreeSet::new));
   }

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectRoleActivator.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectRoleActivator.java
@@ -25,9 +25,8 @@ import com.google.api.client.json.webtoken.JsonWebToken;
 import com.google.api.services.cloudresourcemanager.v3.model.Binding;
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.cel.TemporaryIamCondition;
-import com.google.solutions.jitaccess.cel.TimeSpan;
 import com.google.solutions.jitaccess.core.*;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.*;
 import com.google.solutions.jitaccess.core.clients.ResourceManagerClient;
 import jakarta.enterprise.context.Dependent;
@@ -69,7 +68,7 @@ public class ProjectRoleActivator extends EntitlementActivator<
   private void provisionTemporaryBinding(
     @NotNull String bindingDescription,
     @NotNull ProjectId projectId,
-    @NotNull UserEmail user,
+    @NotNull UserId user,
     @NotNull Set<String> roles,
     @NotNull Instant startTime,
     @NotNull Duration duration
@@ -136,7 +135,7 @@ public class ProjectRoleActivator extends EntitlementActivator<
 
   @Override
   protected Activation provisionAccess(
-    @NotNull UserEmail approvingUser,
+    @NotNull UserId approvingUser,
     @NotNull MpaActivationRequest<ProjectRole> request
   ) throws AccessException, AlreadyExistsException, IOException {
 
@@ -208,11 +207,11 @@ public class ProjectRoleActivator extends EntitlementActivator<
 
         return new MpaRequest<>(
           new ActivationId(payload.getJwtId()),
-          new UserEmail(payload.get("beneficiary").toString()),
+          new UserId(payload.get("beneficiary").toString()),
           Set.of(new ProjectRole(roleBinding)),
           ((List<String>)payload.get("reviewers"))
             .stream()
-            .map(email -> new UserEmail(email))
+            .map(email -> new UserId(email))
             .collect(Collectors.toSet()),
           payload.get("justification").toString(),
           Instant.ofEpochSecond(startTime),

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectRoleRepository.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectRoleRepository.java
@@ -23,7 +23,7 @@ package com.google.solutions.jitaccess.core.catalog.project;
 
 import com.google.solutions.jitaccess.core.AccessException;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.ActivationType;
 import com.google.solutions.jitaccess.core.catalog.EntitlementSet;
 import org.jetbrains.annotations.NotNull;
@@ -42,14 +42,14 @@ public abstract class ProjectRoleRepository {
    * Find projects that a user has standing, JIT-, or MPA-eligible access to.
    */
   abstract @NotNull SortedSet<ProjectId> findProjectsWithEntitlements(
-    @NotNull UserEmail user
+    @NotNull UserId user
   ) throws AccessException, IOException;
 
   /**
    * List entitlements for the given user.
    */
   abstract @NotNull EntitlementSet<ProjectRole> findEntitlements(
-    @NotNull UserEmail user,
+    @NotNull UserId user,
     @NotNull ProjectId projectId,
     @NotNull EnumSet<ActivationType> typesToInclude
   ) throws AccessException, IOException;
@@ -57,7 +57,7 @@ public abstract class ProjectRoleRepository {
   /**
    * List users that hold an eligible role binding.
    */
-  abstract @NotNull Set<UserEmail> findEntitlementHolders(
+  abstract @NotNull Set<UserId> findEntitlementHolders(
     @NotNull ProjectRole roleBinding,
     @NotNull ActivationType activationType
   ) throws AccessException, IOException;

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/clients/DirectoryGroupsClient.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/clients/DirectoryGroupsClient.java
@@ -29,7 +29,7 @@ import com.google.api.services.directory.model.Member;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.core.*;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import jakarta.inject.Singleton;
 import org.jetbrains.annotations.NotNull;
 
@@ -82,7 +82,7 @@ public class DirectoryGroupsClient {
    * List all groups a given user is a direct member of.
    */
   public @NotNull Collection<Group> listDirectGroupMemberships(
-    @NotNull UserEmail user
+    @NotNull UserId user
   ) throws AccessException, IOException {
     try {
       //

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/clients/IamCredentialsClient.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/clients/IamCredentialsClient.java
@@ -29,7 +29,7 @@ import com.google.api.services.iamcredentials.v1.model.SignJwtRequest;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.core.*;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import jakarta.inject.Singleton;
 import org.jetbrains.annotations.NotNull;
 
@@ -77,7 +77,7 @@ public class IamCredentialsClient {
    * Sign a JWT using the Google-managed service account key.
    */
   public String signJwt(
-    @NotNull UserEmail serviceAccount,
+    @NotNull UserId serviceAccount,
     @NotNull JsonWebToken.Payload payload
   ) throws AccessException, IOException {
     Preconditions.checkNotNull(serviceAccount, "serviceAccount");
@@ -120,7 +120,7 @@ public class IamCredentialsClient {
   /**
    * Get JWKS location for service account key set.
    */
-  public static String getJwksUrl(@NotNull UserEmail serviceAccount) {
+  public static String getJwksUrl(@NotNull UserId serviceAccount) {
     return String.format(
       "https://www.googleapis.com/service_accounts/v1/metadata/jwk/%s", 
       serviceAccount.email);

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/clients/PolicyAnalyzerClient.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/clients/PolicyAnalyzerClient.java
@@ -26,7 +26,7 @@ import com.google.api.services.cloudasset.v1.model.IamPolicyAnalysis;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.core.*;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import jakarta.inject.Singleton;
 import org.jetbrains.annotations.NotNull;
 
@@ -59,7 +59,7 @@ public class PolicyAnalyzerClient extends AssetInventoryClient {
    */
   public IamPolicyAnalysis findAccessibleResourcesByUser(
     @NotNull String scope,
-    @NotNull UserEmail user,
+    @NotNull UserId user,
     @NotNull Optional<String> permission,
     @NotNull Optional<String> fullResourceName,
     boolean expandResources

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/clients/SmtpClient.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/clients/SmtpClient.java
@@ -23,7 +23,7 @@ package com.google.solutions.jitaccess.core.clients;
 
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.core.AccessException;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import jakarta.mail.*;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeBodyPart;
@@ -59,8 +59,8 @@ public class SmtpClient {
   }
 
   public void sendMail(
-    @NotNull Collection<UserEmail> toRecipients,
-    @NotNull Collection<UserEmail> ccRecipients,
+    @NotNull Collection<UserId> toRecipients,
+    @NotNull Collection<UserId> ccRecipients,
     @NotNull String subject,
     @NotNull Multipart content,
     @NotNull EnumSet<Flags> flags
@@ -127,8 +127,8 @@ public class SmtpClient {
   }
 
   public void sendMail(
-    @NotNull Collection<UserEmail> toRecipients,
-    @NotNull Collection<UserEmail> ccRecipients,
+    @NotNull Collection<UserId> toRecipients,
+    @NotNull Collection<UserId> ccRecipients,
     @NotNull String subject,
     @NotNull String htmlContent,
     @NotNull EnumSet<Flags> flags

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/notifications/NotificationService.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/notifications/NotificationService.java
@@ -22,7 +22,7 @@
 package com.google.solutions.jitaccess.core.notifications;
 
 import com.google.common.base.Preconditions;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import jakarta.inject.Singleton;
 import org.jetbrains.annotations.NotNull;
 
@@ -76,8 +76,8 @@ public abstract class NotificationService {
    * but doesn't define its format.
    */
   public static abstract class Notification {
-    private final @NotNull Collection<UserEmail> toRecipients;
-    private final @NotNull Collection<UserEmail> ccRecipients;
+    private final @NotNull Collection<UserId> toRecipients;
+    private final @NotNull Collection<UserId> ccRecipients;
     private final @NotNull String subject;
 
     protected final Map<String, Object> properties = new HashMap<>();
@@ -86,11 +86,11 @@ public abstract class NotificationService {
       return false;
     }
 
-    public @NotNull Collection<UserEmail> getToRecipients() {
+    public @NotNull Collection<UserId> getToRecipients() {
       return toRecipients;
     }
 
-    public @NotNull Collection<UserEmail> getCcRecipients() {
+    public @NotNull Collection<UserId> getCcRecipients() {
       return ccRecipients;
     }
 
@@ -104,8 +104,8 @@ public abstract class NotificationService {
     public abstract String getType();
 
     protected Notification(
-      @NotNull Collection<UserEmail> toRecipients,
-      @NotNull Collection<UserEmail> ccRecipients,
+      @NotNull Collection<UserId> toRecipients,
+      @NotNull Collection<UserId> ccRecipients,
       @NotNull String subject
     ) {
       Preconditions.checkNotNull(toRecipients, "toRecipients");

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/IapRequestFilter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/IapRequestFilter.java
@@ -23,10 +23,7 @@ package com.google.solutions.jitaccess.web;
 
 import com.google.auth.oauth2.TokenVerifier;
 import com.google.common.base.Preconditions;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
-import com.google.solutions.jitaccess.web.LogAdapter;
-import com.google.solutions.jitaccess.web.RequireIapPrincipal;
-import com.google.solutions.jitaccess.web.RuntimeEnvironment;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.web.iap.DeviceInfo;
 import com.google.solutions.jitaccess.web.iap.IapAssertion;
 import com.google.solutions.jitaccess.web.iap.IapPrincipal;
@@ -147,8 +144,8 @@ public class IapRequestFilter implements ContainerRequestFilter {
       }
 
       @Override
-      public @NotNull UserEmail email() {
-        return new UserEmail(debugPrincipalName);
+      public @NotNull UserId email() {
+        return new UserId(debugPrincipalName);
       }
 
       @Override

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeEnvironment.java
@@ -32,7 +32,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ImpersonatedCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.solutions.jitaccess.core.ApplicationVersion;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.RegexJustificationPolicy;
 import com.google.solutions.jitaccess.core.catalog.TokenSigner;
 import com.google.solutions.jitaccess.core.catalog.project.*;
@@ -64,7 +64,7 @@ public class RuntimeEnvironment {
 
   private final String projectId;
   private final String projectNumber;
-  private final @NotNull UserEmail applicationPrincipal;
+  private final @NotNull UserId applicationPrincipal;
   private final GoogleCredentials applicationCredentials;
 
   /**
@@ -142,7 +142,7 @@ public class RuntimeEnvironment {
         this.projectNumber = projectMetadata.get("numericProjectId").toString();
 
         var defaultCredentials = (ComputeEngineCredentials)GoogleCredentials.getApplicationDefault();
-        this.applicationPrincipal = new UserEmail(defaultCredentials.getAccount());
+        this.applicationPrincipal = new UserId(defaultCredentials.getAccount());
 
         if (defaultCredentials.getScopes().containsAll(this.configuration.getRequiredOauthScopes())) {
           //
@@ -217,14 +217,14 @@ public class RuntimeEnvironment {
           // refresh fails, fail application startup.
           //
           this.applicationCredentials.refresh();
-          this.applicationPrincipal = new UserEmail(impersonateServiceAccount);
+          this.applicationPrincipal = new UserId(impersonateServiceAccount);
         }
         else if (defaultCredentials instanceof ServiceAccountCredentials) {
           //
           // Use ADC as-is.
           //
           this.applicationCredentials = defaultCredentials;
-          this.applicationPrincipal = new UserEmail(
+          this.applicationPrincipal = new UserId(
               ((ServiceAccountCredentials) this.applicationCredentials).getServiceAccountUser());
         }
         else {
@@ -269,7 +269,7 @@ public class RuntimeEnvironment {
     return projectNumber;
   }
 
-  public @NotNull UserEmail getApplicationPrincipal() {
+  public @NotNull UserId getApplicationPrincipal() {
     return applicationPrincipal;
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/AbstractActivationAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/AbstractActivationAction.java
@@ -23,7 +23,7 @@ package com.google.solutions.jitaccess.web.actions;
 
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.core.RoleBinding;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.*;
 import com.google.solutions.jitaccess.core.catalog.project.ProjectRole;
 import com.google.solutions.jitaccess.core.catalog.project.ProjectRoleActivator;
@@ -94,15 +94,15 @@ public abstract class AbstractActivationAction extends AbstractAction {
   }
 
   public static class ResponseEntity {
-    public final UserEmail beneficiary;
-    public final Collection<UserEmail> reviewers;
+    public final UserId beneficiary;
+    public final Collection<UserId> reviewers;
     public final boolean isBeneficiary;
     public final boolean isReviewer;
     public final String justification;
     public final @NotNull List<Item> items;
 
     public ResponseEntity(
-      @NotNull UserEmail caller,
+      @NotNull UserId caller,
       @NotNull ActivationRequest<ProjectRole> request,
       ActivationStatus status
     ) {

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ApproveActivationRequestAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ApproveActivationRequestAction.java
@@ -25,7 +25,7 @@ import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.AccessException;
 import com.google.solutions.jitaccess.core.util.Exceptions;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.*;
 import com.google.solutions.jitaccess.core.catalog.project.MpaProjectRoleCatalog;
 import com.google.solutions.jitaccess.core.catalog.project.ProjectRole;
@@ -167,7 +167,7 @@ public class ApproveActivationRequestAction extends AbstractActivationAction {
     protected ActivationApprovedNotification(
       ProjectId projectId,
       @NotNull MpaActivationRequest<ProjectRole> request,
-      @NotNull UserEmail approver,
+      @NotNull UserId approver,
       URL activationRequestUrl) throws MalformedURLException
     {
       super(

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ListPeersAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ListPeersAction.java
@@ -26,13 +26,12 @@ import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.AccessException;
 import com.google.solutions.jitaccess.core.util.Exceptions;
 import com.google.solutions.jitaccess.core.RoleBinding;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
 import com.google.solutions.jitaccess.core.catalog.project.MpaProjectRoleCatalog;
 import com.google.solutions.jitaccess.web.LogAdapter;
 import com.google.solutions.jitaccess.web.LogEvents;
 import com.google.solutions.jitaccess.web.iap.IapPrincipal;
-import jakarta.enterprise.context.Dependent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -94,9 +93,9 @@ public class ListPeersAction extends AbstractAction {
 
 
   public static class ResponseEntity {
-    public final @NotNull Set<UserEmail> peers;
+    public final @NotNull Set<UserId> peers;
 
-    private ResponseEntity(@NotNull Set<UserEmail> peers) {
+    private ResponseEntity(@NotNull Set<UserId> peers) {
       Preconditions.checkNotNull(peers);
       this.peers = peers;
     }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/MetadataAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/MetadataAction.java
@@ -23,12 +23,11 @@ package com.google.solutions.jitaccess.web.actions;
 
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.core.ApplicationVersion;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.JustificationPolicy;
 import com.google.solutions.jitaccess.core.catalog.project.MpaProjectRoleCatalog;
 import com.google.solutions.jitaccess.web.LogAdapter;
 import com.google.solutions.jitaccess.web.iap.IapPrincipal;
-import jakarta.enterprise.context.Dependent;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -62,14 +61,14 @@ public class MetadataAction extends AbstractAction {
 
   public static class ResponseEntity {
     public final @NotNull String justificationHint;
-    public final @NotNull UserEmail signedInUser;
+    public final @NotNull UserId signedInUser;
     public final @NotNull String applicationVersion;
     public final int defaultActivationTimeout; // in minutes.
     public final int maxActivationTimeout;     // in minutes.
 
     private ResponseEntity(
       @NotNull String justificationHint,
-      @NotNull UserEmail signedInUser,
+      @NotNull UserId signedInUser,
       @NotNull String applicationVersion,
       int maxActivationTimeoutInMinutes,
       int defaultActivationTimeoutInMinutes

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestActivationAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestActivationAction.java
@@ -26,8 +26,7 @@ import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.AccessException;
 import com.google.solutions.jitaccess.core.util.Exceptions;
 import com.google.solutions.jitaccess.core.RoleBinding;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
-import com.google.solutions.jitaccess.core.catalog.Entitlement;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.MpaActivationRequest;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
 import com.google.solutions.jitaccess.core.catalog.TokenSigner;
@@ -39,7 +38,6 @@ import com.google.solutions.jitaccess.web.LogAdapter;
 import com.google.solutions.jitaccess.web.LogEvents;
 import com.google.solutions.jitaccess.web.RuntimeEnvironment;
 import com.google.solutions.jitaccess.web.iap.IapPrincipal;
-import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Instance;
 import jakarta.ws.rs.core.UriInfo;
 import org.jetbrains.annotations.NotNull;
@@ -126,7 +124,7 @@ public class RequestActivationAction extends AbstractActivationAction {
       activationRequest = this.activator.createMpaRequest(
         userContext,
         Set.of(new ProjectRole(roleBinding)),
-        request.peers.stream().map(email -> new UserEmail(email)).collect(Collectors.toSet()),
+        request.peers.stream().map(email -> new UserId(email)).collect(Collectors.toSet()),
         request.justification,
         Instant.now().truncatedTo(ChronoUnit.SECONDS),
         requestedRoleBindingDuration);

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/iap/IapAssertion.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/iap/IapAssertion.java
@@ -23,7 +23,7 @@ package com.google.solutions.jitaccess.web.iap;
 
 import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.json.webtoken.JsonWebToken;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -45,8 +45,8 @@ public class IapAssertion implements IapPrincipal {
   /**
    * Extract user information
    */
-  public @NotNull UserEmail email() {
-    return new UserEmail(this.payload.get("email").toString());
+  public @NotNull UserId email() {
+    return new UserId(this.payload.get("email").toString());
   }
 
   @Override

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/iap/IapPrincipal.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/iap/IapPrincipal.java
@@ -21,7 +21,7 @@
 
 package com.google.solutions.jitaccess.web.iap;
 
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 
 import java.security.Principal;
 
@@ -29,7 +29,7 @@ import java.security.Principal;
  * Represents a logged-in user.
  */
 public interface IapPrincipal extends Principal {
-  UserEmail email();
+  UserId email();
 
   String subjectId();
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/auth/TestAccessControlList.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/auth/TestAccessControlList.java
@@ -28,13 +28,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Set;
 
 public class TestAccessControlList {
-  private static final UserEmail TEST_USER_1 = new UserEmail("test-1@example.com");
-  private static final UserEmail TEST_USER_2 = new UserEmail("test-2@example.com");
-  private static final GroupEmail TEST_GROUP_1 = new GroupEmail("group-1@example.com");
+  private static final UserId TEST_USER_1 = new UserId("test-1@example.com");
+  private static final UserId TEST_USER_2 = new UserId("test-2@example.com");
+  private static final GroupId TEST_GROUP_1 = new GroupId("group-1@example.com");
 
   private record TestSubject(
-    PrincipalIdentifier id,
-    Set<PrincipalIdentifier> principals) implements Subject {
+    PrincipalId id,
+    Set<PrincipalId> principals) implements Subject {
   }
 
   @Test

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/auth/TestGroupId.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/auth/TestGroupId.java
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -21,19 +21,19 @@
 
 package com.google.solutions.jitaccess.core.auth;
 
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TestUserEmail {
+public class TestGroupId {
   // -------------------------------------------------------------------------
   // toString.
   // -------------------------------------------------------------------------
 
   @Test
   public void toStringReturnsEmail() {
-    assertEquals("test@example.com", new UserEmail("test@example.com").toString());
+    Assertions.assertEquals("test@example.com", new GroupId("test@example.com").toString());
   }
 
   // -------------------------------------------------------------------------
@@ -42,8 +42,8 @@ public class TestUserEmail {
 
   @Test
   public void whenObjectAreEquivalent_ThenEqualsReturnsTrue() {
-    UserEmail id1 = new UserEmail("bob@example.com");
-    UserEmail id2 = new UserEmail("bob@example.com");
+    GroupId id1 = new GroupId("group@example.com");
+    GroupId id2 = new GroupId("group@example.com");
 
     assertTrue(id1.equals(id2));
     assertEquals(id1.hashCode(), id2.hashCode());
@@ -51,15 +51,15 @@ public class TestUserEmail {
 
   @Test
   public void whenObjectAreSame_ThenEqualsReturnsTrue() {
-    UserEmail id1 = new UserEmail("bob@example.com");
+    GroupId id1 = new GroupId("group@example.com");
 
     assertTrue(id1.equals(id1));
   }
 
   @Test
   public void whenObjectAreMotEquivalent_ThenEqualsReturnsFalse() {
-    UserEmail id1 = new UserEmail("alice@example.com");
-    UserEmail id2 = new UserEmail("bob@example.com");
+    GroupId id1 = new GroupId("alice@example.com");
+    GroupId id2 = new GroupId("group@example.com");
 
     assertFalse(id1.equals(id2));
     assertNotEquals(id1.hashCode(), id2.hashCode());
@@ -67,14 +67,14 @@ public class TestUserEmail {
 
   @Test
   public void whenObjectIsNull_ThenEqualsReturnsFalse() {
-    UserEmail id1 = new UserEmail("bob@example.com");
+    GroupId id1 = new GroupId("group@example.com");
 
     assertFalse(id1.equals(null));
   }
 
   @Test
   public void whenObjectIsDifferentType_ThenEqualsReturnsFalse() {
-    UserEmail id1 = new UserEmail("bob@example.com");
+    GroupId id1 = new GroupId("group@example.com");
 
     assertFalse(id1.equals(""));
   }
@@ -86,7 +86,7 @@ public class TestUserEmail {
   @Test
   public void value() {
     assertEquals(
-      "bob@example.com",
-      new UserEmail("bob@example.com").value());
+      "group@example.com",
+      new GroupId("group@example.com").value());
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/auth/TestUserId.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/auth/TestUserId.java
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -21,19 +21,18 @@
 
 package com.google.solutions.jitaccess.core.auth;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TestGroupEmail {
+public class TestUserId {
   // -------------------------------------------------------------------------
   // toString.
   // -------------------------------------------------------------------------
 
   @Test
   public void toStringReturnsEmail() {
-    Assertions.assertEquals("test@example.com", new GroupEmail("test@example.com").toString());
+    assertEquals("test@example.com", new UserId("test@example.com").toString());
   }
 
   // -------------------------------------------------------------------------
@@ -42,8 +41,8 @@ public class TestGroupEmail {
 
   @Test
   public void whenObjectAreEquivalent_ThenEqualsReturnsTrue() {
-    GroupEmail id1 = new GroupEmail("group@example.com");
-    GroupEmail id2 = new GroupEmail("group@example.com");
+    UserId id1 = new UserId("bob@example.com");
+    UserId id2 = new UserId("bob@example.com");
 
     assertTrue(id1.equals(id2));
     assertEquals(id1.hashCode(), id2.hashCode());
@@ -51,15 +50,15 @@ public class TestGroupEmail {
 
   @Test
   public void whenObjectAreSame_ThenEqualsReturnsTrue() {
-    GroupEmail id1 = new GroupEmail("group@example.com");
+    UserId id1 = new UserId("bob@example.com");
 
     assertTrue(id1.equals(id1));
   }
 
   @Test
   public void whenObjectAreMotEquivalent_ThenEqualsReturnsFalse() {
-    GroupEmail id1 = new GroupEmail("alice@example.com");
-    GroupEmail id2 = new GroupEmail("group@example.com");
+    UserId id1 = new UserId("alice@example.com");
+    UserId id2 = new UserId("bob@example.com");
 
     assertFalse(id1.equals(id2));
     assertNotEquals(id1.hashCode(), id2.hashCode());
@@ -67,14 +66,14 @@ public class TestGroupEmail {
 
   @Test
   public void whenObjectIsNull_ThenEqualsReturnsFalse() {
-    GroupEmail id1 = new GroupEmail("group@example.com");
+    UserId id1 = new UserId("bob@example.com");
 
     assertFalse(id1.equals(null));
   }
 
   @Test
   public void whenObjectIsDifferentType_ThenEqualsReturnsFalse() {
-    GroupEmail id1 = new GroupEmail("group@example.com");
+    UserId id1 = new UserId("bob@example.com");
 
     assertFalse(id1.equals(""));
   }
@@ -86,7 +85,7 @@ public class TestGroupEmail {
   @Test
   public void value() {
     assertEquals(
-      "group@example.com",
-      new GroupEmail("group@example.com").value());
+      "bob@example.com",
+      new UserId("bob@example.com").value());
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/ITestTokenSigner.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/ITestTokenSigner.java
@@ -23,7 +23,7 @@ package com.google.solutions.jitaccess.core.catalog;
 
 import com.google.api.client.json.webtoken.JsonWebToken;
 import com.google.auth.oauth2.TokenVerifier;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.clients.HttpTransport;
 import com.google.solutions.jitaccess.core.clients.ITestEnvironment;
 import com.google.solutions.jitaccess.core.clients.IamCredentialsClient;
@@ -35,9 +35,9 @@ import java.time.Instant;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ITestTokenSigner {
-  private static final UserEmail SAMPLE_USER_1 = new UserEmail("user-1@example.com");
-  private static final UserEmail SAMPLE_USER_2 = new UserEmail("user-2@example.com");
-  private static final UserEmail SAMPLE_USER_3 = new UserEmail("user-3@example.com");
+  private static final UserId SAMPLE_USER_1 = new UserId("user-1@example.com");
+  private static final UserId SAMPLE_USER_2 = new UserId("user-2@example.com");
+  private static final UserId SAMPLE_USER_3 = new UserId("user-3@example.com");
 
   private static class PseudoJsonConverter implements JsonWebTokenConverter<JsonWebToken.Payload> {
     @Override

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/TestActivationRequest.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/TestActivationRequest.java
@@ -21,7 +21,7 @@
 
 package com.google.solutions.jitaccess.core.catalog;
 
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -54,7 +54,7 @@ public class TestActivationRequest {
   {
     public SampleActivationRequest(
       ActivationId id,
-      UserEmail user,
+      UserId user,
       Set<SampleEntitlementId> entitlements,
       String justification,
       Instant startTime,
@@ -76,7 +76,7 @@ public class TestActivationRequest {
   public void toStringReturnsSummary() {
     var request = new SampleActivationRequest(
       new ActivationId("sample-1"),
-      new UserEmail("user@example.com"),
+      new UserId("user@example.com"),
       Set.of(
         new SampleEntitlementId("1")),
       "some justification",

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/TestEntitlementActivator.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/TestEntitlementActivator.java
@@ -22,7 +22,7 @@
 package com.google.solutions.jitaccess.core.catalog;
 
 import com.google.solutions.jitaccess.core.*;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -41,12 +41,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class TestEntitlementActivator {
-  private static final UserEmail SAMPLE_REQUESTING_USER = new UserEmail("user@example.com");
-  private static final UserEmail SAMPLE_APPROVING_USER = new UserEmail("peer@example.com");
-  private static final UserEmail SAMPLE_UNKNOWN_USER = new UserEmail("unknown@example.com");
+  private static final UserId SAMPLE_REQUESTING_USER = new UserId("user@example.com");
+  private static final UserId SAMPLE_APPROVING_USER = new UserId("peer@example.com");
+  private static final UserId SAMPLE_UNKNOWN_USER = new UserId("unknown@example.com");
 
   private record UserContext(
-    @NotNull UserEmail user
+    @NotNull UserId user
   ) implements CatalogUserContext {}
 
   private static class SampleActivator extends EntitlementActivator<SampleEntitlementId, ResourceId, UserContext> {
@@ -71,7 +71,7 @@ public class TestEntitlementActivator {
 
     @Override
     protected Activation provisionAccess(
-      UserEmail approvingUser,
+      UserId approvingUser,
       MpaActivationRequest<SampleEntitlementId> request
     ) throws AccessException, AlreadyExistsException, IOException {
       return new Activation(request.startTime(), request.duration());

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/TestRegexActivationPolicy.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/TestRegexActivationPolicy.java
@@ -21,7 +21,7 @@
 
 package com.google.solutions.jitaccess.core.catalog;
 
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestRegexActivationPolicy {
 
-  private static final UserEmail SAMPLE_USER = new UserEmail("user@example.com");
+  private static final UserId SAMPLE_USER = new UserId("user@example.com");
 
   // -------------------------------------------------------------------------
   // checkJustification.

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestAssetInventoryRepository.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestAssetInventoryRepository.java
@@ -29,7 +29,7 @@ import com.google.api.services.directory.model.Group;
 import com.google.api.services.directory.model.Member;
 import com.google.solutions.jitaccess.cel.TemporaryIamCondition;
 import com.google.solutions.jitaccess.core.*;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.ActivationType;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
 import com.google.solutions.jitaccess.core.clients.AssetInventoryClient;
@@ -51,7 +51,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 public class TestAssetInventoryRepository {
-  private static final UserEmail SAMPLE_USER = new UserEmail("user-1@example.com");
+  private static final UserId SAMPLE_USER = new UserId("user-1@example.com");
   private static final ProjectId SAMPLE_PROJECT = new ProjectId("project-1");
   private static final String JIT_CONDITION = "has({}.jitAccessConstraint)";
   private static final String MPA_CONDITION = "has({}.multiPartyApprovalConstraint)";
@@ -469,7 +469,7 @@ public class TestAssetInventoryRepository {
 
     assertNotNull(holders);
     assertEquals(
-      Set.of(new UserEmail("user-1@example.com"), new UserEmail("user-2@example.com")),
+      Set.of(new UserId("user-1@example.com"), new UserId("user-2@example.com")),
       holders);
   }
 
@@ -519,7 +519,7 @@ public class TestAssetInventoryRepository {
 
     assertNotNull(holders);
     assertEquals(
-      Set.of(new UserEmail("user-1@example.com"), new UserEmail("user-2@example.com")),
+      Set.of(new UserId("user-1@example.com"), new UserId("user-2@example.com")),
       holders);
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestMpaProjectRoleCatalog.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestMpaProjectRoleCatalog.java
@@ -24,7 +24,7 @@ package com.google.solutions.jitaccess.core.catalog.project;
 import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
 import com.google.solutions.jitaccess.core.RoleBinding;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.*;
 import com.google.solutions.jitaccess.core.clients.ResourceManagerClient;
 import org.junit.jupiter.api.Test;
@@ -39,8 +39,8 @@ import static org.mockito.Mockito.*;
 
 public class TestMpaProjectRoleCatalog {
 
-  private static final UserEmail SAMPLE_REQUESTING_USER = new UserEmail("user@example.com");
-  private static final UserEmail SAMPLE_APPROVING_USER = new UserEmail("approver@example.com");
+  private static final UserId SAMPLE_REQUESTING_USER = new UserId("user@example.com");
+  private static final UserId SAMPLE_APPROVING_USER = new UserId("approver@example.com");
   private static final ProjectId SAMPLE_PROJECT = new ProjectId("project-1");
   private static final String SAMPLE_ROLE = "roles/resourcemanager.role1";
 
@@ -124,9 +124,9 @@ public class TestMpaProjectRoleCatalog {
     var request = Mockito.mock(MpaActivationRequest.class);
     when(request.duration()).thenReturn(catalog.options().minActivationDuration());
     when(request.reviewers()).thenReturn(Set.of(
-      new UserEmail("user-1@example.com"),
-      new UserEmail("user-2@example.com"),
-      new UserEmail("user-3@example.com")));
+      new UserId("user-1@example.com"),
+      new UserId("user-2@example.com"),
+      new UserId("user-3@example.com")));
 
     assertThrows(
       IllegalArgumentException.class,
@@ -148,7 +148,7 @@ public class TestMpaProjectRoleCatalog {
     var request = Mockito.mock(MpaActivationRequest.class);
     when(request.duration()).thenReturn(catalog.options().minActivationDuration());
     when(request.reviewers()).thenReturn(Set.of(
-      new UserEmail("user-1@example.com")));
+      new UserId("user-1@example.com")));
 
     assertThrows(
       IllegalArgumentException.class,
@@ -170,7 +170,7 @@ public class TestMpaProjectRoleCatalog {
     var request = Mockito.mock(MpaActivationRequest.class);
     when(request.duration()).thenReturn(catalog.options().minActivationDuration());
     when(request.reviewers()).thenReturn(Set.of(
-      new UserEmail("user-1@example.com")));
+      new UserId("user-1@example.com")));
 
     catalog.validateRequest(request);
   }

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestPolicyAnalyzerRepository.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestPolicyAnalyzerRepository.java
@@ -25,9 +25,8 @@ import com.google.api.services.cloudasset.v1.model.*;
 import com.google.solutions.jitaccess.cel.TemporaryIamCondition;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
 import com.google.solutions.jitaccess.core.RoleBinding;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.ActivationType;
-import com.google.solutions.jitaccess.core.catalog.Entitlement;
 import com.google.solutions.jitaccess.core.clients.PolicyAnalyzerClient;
 import com.google.solutions.jitaccess.core.clients.ResourceManagerClient;
 import org.junit.jupiter.api.Test;
@@ -45,9 +44,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 public class TestPolicyAnalyzerRepository {
-  private static final UserEmail SAMPLE_USER = new UserEmail("user-1@example.com");
-  private static final UserEmail SAMPLE_APPROVING_USER_1 = new UserEmail("approver-1@example.com");
-  private static final UserEmail SAMPLE_APPROVING_USER_2 = new UserEmail("approver-2@example.com");
+  private static final UserId SAMPLE_USER = new UserId("user-1@example.com");
+  private static final UserId SAMPLE_APPROVING_USER_1 = new UserId("approver-1@example.com");
+  private static final UserId SAMPLE_APPROVING_USER_2 = new UserId("approver-2@example.com");
   private static final ProjectId SAMPLE_PROJECT_ID_1 = new ProjectId("project-1");
   private static final ProjectId SAMPLE_PROJECT_ID_2 = new ProjectId("project-2");
   private static final String SAMPLE_ROLE_1 = "roles/resourcemanager.role1";
@@ -62,7 +61,7 @@ public class TestPolicyAnalyzerRepository {
   private static IamPolicyAnalysisResult createIamPolicyAnalysisResult(
     String resource,
     String role,
-    UserEmail user
+    UserId user
   ) {
     return new IamPolicyAnalysisResult()
       .setAttachedResourceFullName(resource)
@@ -77,7 +76,7 @@ public class TestPolicyAnalyzerRepository {
   private static IamPolicyAnalysisResult createConditionalIamPolicyAnalysisResult(
     String resource,
     String role,
-    UserEmail user,
+    UserId user,
     String condition,
     String conditionTitle,
     String evaluationResult

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestProjectRoleActivator.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestProjectRoleActivator.java
@@ -25,7 +25,7 @@ import com.google.solutions.jitaccess.cel.TemporaryIamCondition;
 import com.google.solutions.jitaccess.core.catalog.Catalog;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
 import com.google.solutions.jitaccess.core.RoleBinding;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.JustificationPolicy;
 import com.google.solutions.jitaccess.core.clients.ResourceManagerClient;
 import org.junit.jupiter.api.Test;
@@ -44,8 +44,8 @@ import static org.mockito.Mockito.verify;
 
 public class TestProjectRoleActivator {
 
-  private static final UserEmail SAMPLE_REQUESTING_USER = new UserEmail("user@example.com");
-  private static final UserEmail SAMPLE_APPROVING_USER = new UserEmail("approver@example.com");
+  private static final UserId SAMPLE_REQUESTING_USER = new UserId("user@example.com");
+  private static final UserId SAMPLE_APPROVING_USER = new UserId("approver@example.com");
   private static final ProjectId SAMPLE_PROJECT = new ProjectId("project-1");
   private static final String SAMPLE_ROLE_1 = "roles/resourcemanager.role1";
   private static final String SAMPLE_ROLE_2 = "roles/resourcemanager.role2";

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/clients/ITestCloudIdentityGroupsClient.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/clients/ITestCloudIdentityGroupsClient.java
@@ -22,8 +22,8 @@
 package com.google.solutions.jitaccess.core.clients;
 
 import com.google.solutions.jitaccess.core.*;
-import com.google.solutions.jitaccess.core.auth.GroupEmail;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.GroupId;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class ITestCloudIdentityGroupsClient {
   private final String INVALID_CUSTOMER_ID = "Cinvalid";
-  private static final GroupEmail TEST_GROUP_EMAIL = new GroupEmail(
+  private static final GroupId TEST_GROUP_EMAIL = new GroupId(
     String.format(
       "jitaccess-test@%s",
       ITestEnvironment.CLOUD_IDENTITY_DOMAIN));
@@ -70,7 +70,7 @@ public class ITestCloudIdentityGroupsClient {
 
     assertThrows(
       NotAuthenticatedException.class,
-      () -> client.getGroup(new GroupEmail("test@example.com")));
+      () -> client.getGroup(new GroupId("test@example.com")));
   }
 
   @Test
@@ -83,7 +83,7 @@ public class ITestCloudIdentityGroupsClient {
 
     assertThrows(
       AccessDeniedException.class,
-      () -> client.getGroup(new GroupEmail("test@example.com")));
+      () -> client.getGroup(new GroupId("test@example.com")));
   }
 
   @Test
@@ -96,7 +96,7 @@ public class ITestCloudIdentityGroupsClient {
 
     assertThrows(
       AccessDeniedException.class,
-      () -> client.getGroup(new GroupEmail(String.format(
+      () -> client.getGroup(new GroupId(String.format(
         "jitaccess-doesnotexist@%s",
         ITestEnvironment.CLOUD_IDENTITY_DOMAIN))));
   }
@@ -129,7 +129,7 @@ public class ITestCloudIdentityGroupsClient {
     assertThrows(
       NotAuthenticatedException.class,
       () -> client.createGroup(
-        new GroupEmail("test@example.com"),
+        new GroupId("test@example.com"),
         "test group"));
   }
 
@@ -144,7 +144,7 @@ public class ITestCloudIdentityGroupsClient {
     assertThrows(
       IllegalArgumentException.class,
       () -> client.createGroup(
-        new GroupEmail("doesnotexist@google.com"),
+        new GroupId("doesnotexist@google.com"),
         "test group"));
   }
 
@@ -262,7 +262,7 @@ public class ITestCloudIdentityGroupsClient {
       NotAuthenticatedException.class,
       () -> client.addMembership(
         new GroupKey("test"),
-        new UserEmail("user@example.com"),
+        new UserId("user@example.com"),
         Instant.now().plusSeconds(300)));
   }
 
@@ -278,7 +278,7 @@ public class ITestCloudIdentityGroupsClient {
       IllegalArgumentException.class,
       () -> client.addMembership(
         new GroupKey("invalid"),
-        new UserEmail("user@example.com"),
+        new UserId("user@example.com"),
         Instant.now().plusSeconds(300)));
   }
 
@@ -479,7 +479,7 @@ public class ITestCloudIdentityGroupsClient {
     assertThrows(
       ResourceNotFoundException.class,
       () -> client.listMembershipsByUser(
-      new UserEmail("doesnotexist@" + ITestEnvironment.CLOUD_IDENTITY_DOMAIN)));
+      new UserId("doesnotexist@" + ITestEnvironment.CLOUD_IDENTITY_DOMAIN)));
   }
 
   @Test

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/clients/ITestEnvironment.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/clients/ITestEnvironment.java
@@ -26,7 +26,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ImpersonatedCredentials;
 import com.google.common.base.Strings;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -52,12 +52,12 @@ public class ITestEnvironment {
   /**
    * Service account that tests can use to grant temporary access to.
    */
-  public static final UserEmail TEMPORARY_ACCESS_USER;
+  public static final UserId TEMPORARY_ACCESS_USER;
 
   /**
    * Service account that doesn't have access to anything.
    */
-  public static final UserEmail NO_ACCESS_USER;
+  public static final UserId NO_ACCESS_USER;
 
   /**
    * Credentials with application-level access.
@@ -112,10 +112,10 @@ public class ITestEnvironment {
       // User settings.
       //
 
-      NO_ACCESS_USER = new UserEmail(
+      NO_ACCESS_USER = new UserId(
         String.format("%s@%s.iam.gserviceaccount.com", "no-access", PROJECT_ID));
 
-      TEMPORARY_ACCESS_USER = new UserEmail(
+      TEMPORARY_ACCESS_USER = new UserId(
         String.format("%s@%s.iam.gserviceaccount.com", "temporary-access", PROJECT_ID));
 
       var defaultCredentials = GoogleCredentials

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/clients/ITestPolicyAnalyzerClient.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/clients/ITestPolicyAnalyzerClient.java
@@ -23,7 +23,7 @@ package com.google.solutions.jitaccess.core.clients;
 
 import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.NotAuthenticatedException;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.junit.jupiter.api.Test;
 
 import java.net.SocketTimeoutException;
@@ -48,7 +48,7 @@ public class ITestPolicyAnalyzerClient {
       NotAuthenticatedException.class,
       () -> adapter.findAccessibleResourcesByUser(
         "projects/0",
-        new UserEmail("bob@example.com"),
+        new UserId("bob@example.com"),
         Optional.empty(),
         Optional.empty(),
         true));
@@ -64,7 +64,7 @@ public class ITestPolicyAnalyzerClient {
       AccessDeniedException.class,
       () -> adapter.findAccessibleResourcesByUser(
         "projects/0",
-        new UserEmail("bob@example.com"),
+        new UserId("bob@example.com"),
         Optional.empty(),
         Optional.empty(),
         true));
@@ -83,7 +83,7 @@ public class ITestPolicyAnalyzerClient {
       SocketTimeoutException.class,
       () -> adapter.findAccessibleResourcesByUser(
         "projects/0",
-        new UserEmail("bob@example.com"),
+        new UserId("bob@example.com"),
         Optional.empty(),
         Optional.empty(),
         true));
@@ -97,7 +97,7 @@ public class ITestPolicyAnalyzerClient {
 
     var result = adapter.findAccessibleResourcesByUser(
       "projects/" + ITestEnvironment.PROJECT_ID,
-      new UserEmail("bob@example.com"),
+      new UserId("bob@example.com"),
       Optional.of("invalid.invalid.invalid"),
       Optional.empty(),
       true);
@@ -114,7 +114,7 @@ public class ITestPolicyAnalyzerClient {
 
     var result = adapter.findAccessibleResourcesByUser(
       "projects/" + ITestEnvironment.PROJECT_ID,
-      new UserEmail("bob@example.com"),
+      new UserId("bob@example.com"),
       Optional.empty(),
       Optional.of("//cloudresourcemanager.googleapis.com/projects/000-invalid"),
       true);

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/clients/TestGroupKey.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/clients/TestGroupKey.java
@@ -21,8 +21,7 @@
 
 package com.google.solutions.jitaccess.core.clients;
 
-import com.google.solutions.jitaccess.core.auth.UserEmail;
-import com.google.solutions.jitaccess.core.clients.GroupKey;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -87,7 +86,7 @@ public class TestGroupKey {
   @Test
   public void whenObjectIsDifferentType_ThenEqualsReturnsFalse() {
     var id = new GroupKey("group-1");
-    var email = new UserEmail("group-1@example.com");
+    var email = new UserId("group-1@example.com");
 
     assertFalse(id.equals(email));
   }

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/notifications/TestMailNotificationService.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/notifications/TestMailNotificationService.java
@@ -21,7 +21,7 @@
 
 package com.google.solutions.jitaccess.core.notifications;
 
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.clients.SmtpClient;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -42,7 +42,7 @@ public class TestMailNotificationService {
     private final String templateId;
 
     protected TestNotification(
-      UserEmail recipient,
+      UserId recipient,
       String subject,
       Map<String, Object> properties,
       String templateId
@@ -72,7 +72,7 @@ public class TestMailNotificationService {
       mailAdapter,
       new MailNotificationService.Options(MailNotificationService.Options.DEFAULT_TIMEZONE));
 
-    var to = new UserEmail("user@example.com");
+    var to = new UserId("user@example.com");
     service.sendNotification(new TestNotification(
       to,
       "Test email",
@@ -94,7 +94,7 @@ public class TestMailNotificationService {
       mailAdapter,
       new MailNotificationService.Options(MailNotificationService.Options.DEFAULT_TIMEZONE));
 
-    var to = new UserEmail("user@example.com");
+    var to = new UserId("user@example.com");
     service.sendNotification(new TestNotification(
       to,
       "Test email",

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/notifications/TestMessageTemplate.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/notifications/TestMessageTemplate.java
@@ -22,7 +22,7 @@
 package com.google.solutions.jitaccess.core.notifications;
 
 import com.google.common.html.HtmlEscapers;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -39,7 +39,7 @@ public class TestMessageTemplate {
     private final String templateId;
 
     protected TestNotification(
-      UserEmail recipient,
+      UserId recipient,
       String subject,
       Map<String, Object> properties,
       String templateId
@@ -69,7 +69,7 @@ public class TestMessageTemplate {
     properties.put("TEST-2", "<value2/>");
 
     var notification = new TestNotification(
-      new UserEmail("user@example.com"),
+      new UserId("user@example.com"),
       "Test email",
       properties,
       "ignored-templateid");
@@ -94,7 +94,7 @@ public class TestMessageTemplate {
     properties.put("TEST-1", Instant.ofEpochSecond(86400));
 
     var notification = new TestNotification(
-      new UserEmail("user@example.com"),
+      new UserId("user@example.com"),
       "Test email",
       properties,
       "ignored-templateid");

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/notifications/TestPubSubNotificationService.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/notifications/TestPubSubNotificationService.java
@@ -21,7 +21,7 @@
 
 package com.google.solutions.jitaccess.core.notifications;
 
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.clients.PubSubClient;
 import com.google.solutions.jitaccess.core.clients.PubSubTopic;
 import org.junit.jupiter.api.Test;
@@ -45,8 +45,8 @@ public class TestPubSubNotificationService {
   private class SampleNotification extends NotificationService.Notification {
 
     protected SampleNotification(
-      Collection<UserEmail> toRecipients,
-      Collection<UserEmail> ccRecipients,
+      Collection<UserId> toRecipients,
+      Collection<UserId> ccRecipients,
       String subject) {
       super(toRecipients, ccRecipients, subject);
 
@@ -54,7 +54,7 @@ public class TestPubSubNotificationService {
       this.properties.put("instant", Instant.ofEpochSecond(0));
       this.properties.put(
         "user_list",
-        List.of(new UserEmail("alice@example.com"), new UserEmail("bob@example.com")));
+        List.of(new UserId("alice@example.com"), new UserId("bob@example.com")));
     }
 
     @Override
@@ -73,8 +73,8 @@ public class TestPubSubNotificationService {
 
     service.sendNotification(
       new SampleNotification(
-        List.of(new UserEmail("to@example.com")),
-        List.of(new UserEmail("cc@example.com")),
+        List.of(new UserId("to@example.com")),
+        List.of(new UserId("cc@example.com")),
         "subject"));
 
     var expectedMessage =

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/RestDispatcher.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/RestDispatcher.java
@@ -22,8 +22,7 @@
 package com.google.solutions.jitaccess.web;
 
 import com.google.gson.Gson;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
-import com.google.solutions.jitaccess.web.ExceptionMappers;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.web.iap.DeviceInfo;
 import com.google.solutions.jitaccess.web.iap.IapPrincipal;
 import jakarta.ws.rs.core.MediaType;
@@ -42,7 +41,7 @@ import java.security.Principal;
 public class RestDispatcher<TResource> {
   private final Dispatcher dispatcher;
 
-  public RestDispatcher(TResource resource, final UserEmail userEmail) {
+  public RestDispatcher(TResource resource, final UserId userId) {
     dispatcher = MockDispatcherFactory.createDispatcher();
     dispatcher.getRegistry().addSingletonResource(resource);
 
@@ -63,8 +62,8 @@ public class RestDispatcher<TResource> {
         public Principal getUserPrincipal() {
           return new IapPrincipal() {
             @Override
-            public UserEmail email() {
-              return userEmail;
+            public UserId email() {
+              return userId;
             }
 
             @Override

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestExceptionMapper.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestExceptionMapper.java
@@ -25,7 +25,7 @@ import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.AccessException;
 import com.google.solutions.jitaccess.core.NotAuthenticatedException;
 import com.google.solutions.jitaccess.core.ResourceNotFoundException;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
@@ -38,7 +38,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestExceptionMapper {
-  private static final UserEmail SAMPLE_USER = new UserEmail("user-1@example.com");
+  private static final UserId SAMPLE_USER = new UserId("user-1@example.com");
 
   @Path("/api/")
   public class Resource {

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestLogAdapter.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestLogAdapter.java
@@ -21,7 +21,7 @@
 
 package com.google.solutions.jitaccess.web;
 
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.web.iap.DeviceInfo;
 import com.google.solutions.jitaccess.web.iap.IapPrincipal;
 import org.junit.jupiter.api.Test;
@@ -39,8 +39,8 @@ public class TestLogAdapter {
     adapter.setPrincipal(
       new IapPrincipal() {
         @Override
-        public UserEmail email() {
-          return new UserEmail("email");
+        public UserId email() {
+          return new UserId("email");
         }
 
         @Override
@@ -76,8 +76,8 @@ public class TestLogAdapter {
     adapter.setPrincipal(
       new IapPrincipal() {
         @Override
-        public UserEmail email() {
-          return new UserEmail("email");
+        public UserId email() {
+          return new UserId("email");
         }
 
         @Override

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/actions/Mocks.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/actions/Mocks.java
@@ -21,7 +21,7 @@
 
 package com.google.solutions.jitaccess.web.actions;
 
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.project.MpaProjectRoleCatalog;
 import com.google.solutions.jitaccess.core.notifications.NotificationService;
 import com.google.solutions.jitaccess.web.RuntimeEnvironment;
@@ -61,11 +61,11 @@ abstract class Mocks {
     return environment;
   }
 
-  static IapPrincipal createIapPrincipalMock(@NotNull UserEmail userEmail) {
+  static IapPrincipal createIapPrincipalMock(@NotNull UserId userId) {
     return new IapPrincipal() {
       @Override
-      public UserEmail email() {
-        return userEmail;
+      public UserId email() {
+        return userId;
       }
 
       @Override

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestApproveActivationRequestAction.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestApproveActivationRequestAction.java
@@ -24,7 +24,7 @@ package com.google.solutions.jitaccess.web.actions;
 import com.google.auth.oauth2.TokenVerifier;
 import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.RoleBinding;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.*;
 import com.google.solutions.jitaccess.core.catalog.project.MpaProjectRoleCatalog;
 import com.google.solutions.jitaccess.core.catalog.project.ProjectRole;
@@ -48,8 +48,8 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 public class TestApproveActivationRequestAction {
-  private static final UserEmail SAMPLE_USER = new UserEmail("user-1@example.com");
-  private static final UserEmail SAMPLE_USER_2 = new UserEmail("user-2@example.com");
+  private static final UserId SAMPLE_USER = new UserId("user-1@example.com");
+  private static final UserId SAMPLE_USER_2 = new UserId("user-2@example.com");
   private static final String SAMPLE_TOKEN = "eySAMPLE";
 
   @Test

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestIntrospectActivationRequestAction.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestIntrospectActivationRequestAction.java
@@ -24,7 +24,7 @@ package com.google.solutions.jitaccess.web.actions;
 import com.google.auth.oauth2.TokenVerifier;
 import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.RoleBinding;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.Catalog;
 import com.google.solutions.jitaccess.core.catalog.JustificationPolicy;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
@@ -50,8 +50,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 public class TestIntrospectActivationRequestAction {
-  private static final UserEmail SAMPLE_USER = new UserEmail("user-1@example.com");
-  private static final UserEmail SAMPLE_USER_2 = new UserEmail("user-2@example.com");
+  private static final UserId SAMPLE_USER = new UserId("user-1@example.com");
+  private static final UserId SAMPLE_USER_2 = new UserId("user-2@example.com");
   private static final String SAMPLE_TOKEN = "eySAMPLE";
 
   @Test
@@ -107,7 +107,7 @@ public class TestIntrospectActivationRequestAction {
     assertThrows(
       AccessDeniedException.class,
       () -> action.execute(
-        Mocks.createIapPrincipalMock(new UserEmail("other-party@example.com")),
+        Mocks.createIapPrincipalMock(new UserId("other-party@example.com")),
         TokenObfuscator.encode(SAMPLE_TOKEN)));
   }
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestListPeersAction.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestListPeersAction.java
@@ -22,7 +22,7 @@
 package com.google.solutions.jitaccess.web.actions;
 
 import com.google.solutions.jitaccess.core.AccessDeniedException;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.web.LogAdapter;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +35,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 
 public class TestListPeersAction {
-  private static final UserEmail SAMPLE_USER = new UserEmail("user-1@example.com");
+  private static final UserId SAMPLE_USER = new UserId("user-1@example.com");
 
   @Test
   public void whenCatalogThrowsAccessDeniedException_ThenActionThrowsException() throws Exception {
@@ -73,7 +73,7 @@ public class TestListPeersAction {
       .listReviewers(
         argThat(ctx -> ctx.user().equals(SAMPLE_USER)),
         argThat(r -> r.roleBinding().role().equals("roles/browser"))))
-      .thenReturn(new TreeSet(Set.of(new UserEmail("peer-1@example.com"), new UserEmail("peer-2@example.com"))));
+      .thenReturn(new TreeSet(Set.of(new UserId("peer-1@example.com"), new UserId("peer-2@example.com"))));
 
     var action = new ListPeersAction(new LogAdapter(), catalog);
     var response = action.execute(Mocks.createIapPrincipalMock(SAMPLE_USER), "project-1", "roles/browser");

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestListRolesAction.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestListRolesAction.java
@@ -23,7 +23,7 @@ package com.google.solutions.jitaccess.web.actions;
 
 import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.RoleBinding;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.ActivationType;
 import com.google.solutions.jitaccess.core.catalog.Entitlement;
 import com.google.solutions.jitaccess.core.catalog.EntitlementSet;
@@ -43,7 +43,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
 public class TestListRolesAction {
-  private static final UserEmail SAMPLE_USER = new UserEmail("user-1@example.com");
+  private static final UserId SAMPLE_USER = new UserId("user-1@example.com");
 
   @Test
   public void whenProjectIsEmpty_ThenActionThrowsException() throws Exception {

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestListScopesAction.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestListScopesAction.java
@@ -21,7 +21,7 @@
 
 package com.google.solutions.jitaccess.web.actions;
 
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
 import com.google.solutions.jitaccess.web.LogAdapter;
 import org.junit.jupiter.api.Test;
@@ -35,7 +35,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 
 public class TestListScopesAction {
-  private static final UserEmail SAMPLE_USER = new UserEmail("user-1@example.com");
+  private static final UserId SAMPLE_USER = new UserId("user-1@example.com");
 
   @Test
   public void whenCatalogReturnsNoProjects_ThenResponseContainsEmptyList() throws Exception {

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestMetadataAction.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestMetadataAction.java
@@ -21,7 +21,7 @@
 
 package com.google.solutions.jitaccess.web.actions;
 
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.JustificationPolicy;
 import com.google.solutions.jitaccess.core.catalog.project.MpaProjectRoleCatalog;
 import com.google.solutions.jitaccess.web.LogAdapter;
@@ -39,7 +39,7 @@ public class TestMetadataAction {
   private static final int DEFAULT_MAX_NUMBER_OF_REVIEWERS = 10;
   private static final Duration DEFAULT_ACTIVATION_DURATION = Duration.ofMinutes(5);
 
-  private static final UserEmail SAMPLE_USER = new UserEmail("user-1@example.com");
+  private static final UserId SAMPLE_USER = new UserId("user-1@example.com");
 
 
   @Test

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestRequestActivationAction.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestRequestActivationAction.java
@@ -23,8 +23,7 @@ package com.google.solutions.jitaccess.web.actions;
 
 import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.RoleBinding;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
-import com.google.solutions.jitaccess.core.catalog.Entitlement;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.JustificationPolicy;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
 import com.google.solutions.jitaccess.core.catalog.TokenSigner;
@@ -48,8 +47,8 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
 public class TestRequestActivationAction {
-  private static final UserEmail SAMPLE_USER = new UserEmail("user-1@example.com");
-  private static final UserEmail SAMPLE_USER_2 = new UserEmail("user-2@example.com");
+  private static final UserId SAMPLE_USER = new UserId("user-1@example.com");
+  private static final UserId SAMPLE_USER_2 = new UserId("user-2@example.com");
   private static final Duration DEFAULT_ACTIVATION_DURATION = Duration.ofMinutes(5);
   private static final int DEFAULT_MIN_NUMBER_OF_REVIEWERS = 1;
   private static final int DEFAULT_MAX_NUMBER_OF_REVIEWERS = 10;
@@ -418,7 +417,7 @@ public class TestRequestActivationAction {
       Mocks.createUriInfoMock());
 
     assertEquals(SAMPLE_USER.email, response.beneficiary.email);
-    assertIterableEquals(Set.of(new UserEmail(SAMPLE_USER_2.email)), response.reviewers);
+    assertIterableEquals(Set.of(new UserId(SAMPLE_USER_2.email)), response.reviewers);
     assertTrue(response.isBeneficiary);
     assertFalse(response.isReviewer);
     assertEquals("justification", response.justification);

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestRequestAndSelfApproveAction.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/actions/TestRequestAndSelfApproveAction.java
@@ -23,12 +23,9 @@ package com.google.solutions.jitaccess.web.actions;
 
 import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.RoleBinding;
-import com.google.solutions.jitaccess.core.auth.UserEmail;
+import com.google.solutions.jitaccess.core.auth.UserId;
 import com.google.solutions.jitaccess.core.catalog.Activation;
-import com.google.solutions.jitaccess.core.catalog.ActivationRequest;
-import com.google.solutions.jitaccess.core.catalog.Entitlement;
 import com.google.solutions.jitaccess.core.catalog.ProjectId;
-import com.google.solutions.jitaccess.core.catalog.project.ProjectRole;
 import com.google.solutions.jitaccess.core.catalog.project.ProjectRoleActivator;
 import com.google.solutions.jitaccess.web.LogAdapter;
 import com.google.solutions.jitaccess.web.RuntimeEnvironment;
@@ -46,7 +43,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 
 public class TestRequestAndSelfApproveAction {
-  private static final UserEmail SAMPLE_USER = new UserEmail("user-1@example.com");
+  private static final UserId SAMPLE_USER = new UserId("user-1@example.com");
 
   @Test
   public void whenProjectIsNull_ThenActionThrowsException() throws Exception {


### PR DESCRIPTION
Change class names to emphasize that the user IDs
and group IDs as used by IAM don't necessarily correspond to routable email addresses.