### PR TITLE
Fix case sensitive match of principal emails

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/AssetInventoryRepository.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/AssetInventoryRepository.java
@@ -302,14 +302,15 @@ public class AssetInventoryRepository extends ProjectRoleRepository {
     ) {
       this.principalIdentifiers = groups
         .stream()
-        .map(g -> String.format("group:%s", g.getEmail()))
+        .map(g -> String.format("group:%s", g.getEmail().toLowerCase()))
         .collect(Collectors.toSet());
-      this.principalIdentifiers.add(String.format("user:%s", user.email));
+      this.principalIdentifiers.add(String.format("user:%s", user.email).toLowerCase());
     }
 
     public boolean isMember(@NotNull Binding binding) {
       return binding.getMembers()
         .stream()
+        .map(String::toLowerCase)
         .anyMatch(member -> this.principalIdentifiers.contains(member));
     }
   }


### PR DESCRIPTION
Hi,

We just switched to the AssetInventory catalog, but encountered problems with retrieving the JIT-roles for our users. 
After some local debugging we discovered that it was caused by inconsistent casing of the email-field between the retrieved groups for a user, and the EffectiveIamPolicies member results.

Our groups are synced from EntraID to GCP with uppercase naming, but the EffectiveIamPolicies result contained members with email as lowercase.

The proposed change is probably not the best way to fix this, but I wanted to get your thoughts on the matter before i put more effort into this.