### PR TITLE
Ignore case when comparing user and group IDs

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/auth/GroupId.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/auth/GroupId.java
@@ -39,7 +39,7 @@ public class GroupId implements Comparable<GroupId>, PrincipalId {
 
   public GroupId(@NotNull String email) {
     Preconditions.checkNotNull(email, "email");
-    this.email = email;
+    this.email = email.toLowerCase();
   }
 
   @Override

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/auth/GroupId.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/auth/GroupId.java
@@ -39,6 +39,10 @@ public class GroupId implements Comparable<GroupId>, PrincipalId {
 
   public GroupId(@NotNull String email) {
     Preconditions.checkNotNull(email, "email");
+
+    //
+    // Use lower-case as canonical format.
+    //
     this.email = email.toLowerCase();
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/auth/UserId.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/auth/UserId.java
@@ -40,6 +40,10 @@ public class UserId implements Comparable<UserId>, PrincipalId {
 
   public UserId(@NotNull String email) {
     Preconditions.checkNotNull(email, "email");
+
+    //
+    // Use lower-case as canonical format.
+    //
     this.email = email.toLowerCase();
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/auth/UserId.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/auth/UserId.java
@@ -40,7 +40,7 @@ public class UserId implements Comparable<UserId>, PrincipalId {
 
   public UserId(@NotNull String email) {
     Preconditions.checkNotNull(email, "email");
-    this.email = email;
+    this.email = email.toLowerCase();
   }
 
   @Override

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/auth/TestGroupId.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/auth/TestGroupId.java
@@ -32,8 +32,9 @@ public class TestGroupId {
   // -------------------------------------------------------------------------
 
   @Test
-  public void toStringReturnsEmail() {
+  public void toStringReturnsEmailInLowerCase() {
     Assertions.assertEquals("test@example.com", new GroupId("test@example.com").toString());
+    Assertions.assertEquals("test@example.com", new GroupId("Test@Example.com").toString());
   }
 
   // -------------------------------------------------------------------------
@@ -47,6 +48,17 @@ public class TestGroupId {
 
     assertTrue(id1.equals(id2));
     assertEquals(id1.hashCode(), id2.hashCode());
+    assertEquals(0, id1.compareTo(id2));
+  }
+
+  @Test
+  public void whenObjectAreEquivalentButDifferInCasing_ThenEqualsReturnsTrue() {
+    GroupId id1 = new GroupId("Group@Example.com");
+    GroupId id2 = new GroupId("group@example.com");
+
+    assertTrue(id1.equals(id2));
+    assertEquals(id1.hashCode(), id2.hashCode());
+    assertEquals(0, id1.compareTo(id2));
   }
 
   @Test
@@ -54,6 +66,7 @@ public class TestGroupId {
     GroupId id1 = new GroupId("group@example.com");
 
     assertTrue(id1.equals(id1));
+    assertEquals(0, id1.compareTo(id1));
   }
 
   @Test
@@ -63,6 +76,7 @@ public class TestGroupId {
 
     assertFalse(id1.equals(id2));
     assertNotEquals(id1.hashCode(), id2.hashCode());
+    assertNotEquals(0, id1.compareTo(id2));
   }
 
   @Test

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/auth/TestUserId.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/auth/TestUserId.java
@@ -31,8 +31,9 @@ public class TestUserId {
   // -------------------------------------------------------------------------
 
   @Test
-  public void toStringReturnsEmail() {
+  public void toStringReturnsEmailInLowerCase() {
     assertEquals("test@example.com", new UserId("test@example.com").toString());
+    assertEquals("test@example.com", new UserId("Test@Example.com").toString());
   }
 
   // -------------------------------------------------------------------------
@@ -46,6 +47,17 @@ public class TestUserId {
 
     assertTrue(id1.equals(id2));
     assertEquals(id1.hashCode(), id2.hashCode());
+    assertEquals(0, id1.compareTo(id2));
+  }
+
+  @Test
+  public void whenObjectAreEquivalentButDifferInCasing_ThenEqualsReturnsTrue() {
+    UserId id1 = new UserId("Bob@Example.Com");
+    UserId id2 = new UserId("bob@example.com");
+
+    assertTrue(id1.equals(id2));
+    assertEquals(id1.hashCode(), id2.hashCode());
+    assertEquals(0, id1.compareTo(id2));
   }
 
   @Test
@@ -53,6 +65,7 @@ public class TestUserId {
     UserId id1 = new UserId("bob@example.com");
 
     assertTrue(id1.equals(id1));
+    assertEquals(0, id1.compareTo(id1));
   }
 
   @Test
@@ -62,6 +75,7 @@ public class TestUserId {
 
     assertFalse(id1.equals(id2));
     assertNotEquals(id1.hashCode(), id2.hashCode());
+    assertNotEquals(0, id1.compareTo(id2));
   }
 
   @Test

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestAssetInventoryRepository.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestAssetInventoryRepository.java
@@ -141,11 +141,15 @@ public class TestAssetInventoryRepository {
       .setMembers(List.of("serviceAccount:other@example.iam.gserviceaccount.com"));
     var permanentBindingForUser = new Binding()
       .setRole("roles/for-user-permanent")
-      .setMembers(List.of("user:" + SAMPLE_USER.email, "user:other@example.com"));
+      .setMembers(List.of(
+        "user:" + SAMPLE_USER.email.toLowerCase(),  // Usernames are case-insensitive
+        "user:other@example.com"));
     var conditionalBindingForUser = new Binding()
       .setRole("roles/for-user-conditional")
       .setCondition(new Expr().setExpression("true"))
-      .setMembers(List.of("user:" + SAMPLE_USER.email, "user:other@example.com"));
+      .setMembers(List.of(
+        "user:" + SAMPLE_USER.email.toUpperCase(),   // Usernames are case-insensitive
+        "user:other@example.com"));
 
     var caiClient = Mockito.mock(AssetInventoryClient.class);
     when(caiClient
@@ -197,7 +201,7 @@ public class TestAssetInventoryRepository {
     when(groupsClient
       .listDirectGroupMemberships(eq(SAMPLE_USER)))
       .thenReturn(List.of(
-        new Group().setEmail("group-1@example.com"),
+        new Group().setEmail("GROUP-1@EXAMPLE.COM"), // Group names are case-insensitive
         new Group().setEmail("group-2@example.com"),
         new Group().setEmail("junk@example.com")));
 


### PR DESCRIPTION
IAM policies might contain group IDs in different casing
than returned by the Directory API.

Cf #369

Co-authored-by: Johannes Bråthen Oma <johannes.oma@kartverket.no>