### PR TITLE
b/325372861 Handle 403 errors when creating groups

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/clients/CloudIdentityGroupsClient.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/clients/CloudIdentityGroupsClient.java
@@ -211,10 +211,13 @@ public class CloudIdentityGroupsClient {
         groupKey = new GroupKey((String)createOperation.getResponse().get("name"));
       }
       catch (GoogleJsonResponseException e) {
-        if (isAlreadyExistsError(e)) {
+        if (isAlreadyExistsError(e) || e.getStatusCode() == 403) {
           //
           // Group already exists. That's ok, but we need to find out
           // its ID.
+          //
+          // NB. A 403 could also be a permission-denied error. If that's
+          // the case, the following call will fail.
           //
           groupKey = lookupGroup(client, emailAddress);
         }


### PR DESCRIPTION
The API might return a 403 status if the group exists, despite sufficient access.