### PR TITLE
b/338512999 Allow eligible roles to specify resource condition

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/cel/TemporaryIamCondition.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/cel/TemporaryIamCondition.java
@@ -40,8 +40,8 @@ public class TemporaryIamCondition extends IamCondition {
     "(request.time >= timestamp(\"%s\") && " + "request.time < timestamp(\"%s\"))";
 
   private static final String CONDITION_PATTERN =
-    "^\\s*\\(request.time >= timestamp\\(\\\"(.*)\\\"\\) && "
-      + "request.time < timestamp\\(\\\"(.*)\\\"\\)\\)\\s*$";
+    "^\\s*[\\(]+request.time >= timestamp\\(\\\"(.*)\\\"\\) && "
+      + "request.time < timestamp\\(\\\"(.*)\\\"\\)[\\)]+\\s*$";
 
   private static final Pattern CONDITION = Pattern.compile(CONDITION_PATTERN);
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/EntitlementId.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/EntitlementId.java
@@ -40,6 +40,13 @@ public abstract class EntitlementId implements Comparable<EntitlementId> {
    */
   public abstract @NotNull String id();
 
+  /**
+   * @return Optional condition that constrains this entitlement.
+   */
+  public @Nullable String resourceCondition() {
+    return null;
+  }
+
   @Override
   public String toString() {
     return String.format("%s:%s", this.catalog(), this.id());

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/AssetInventoryRepository.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/AssetInventoryRepository.java
@@ -56,22 +56,6 @@ public class AssetInventoryRepository extends ProjectRoleRepository {
   private final @NotNull DirectoryGroupsClient groupsClient;
   private final @NotNull AssetInventoryClient assetInventoryClient;
 
-  private static @NotNull String createEntitlementName(
-    @NotNull Binding binding,
-    @NotNull ProjectRole role
-  ) {
-    if (role.resourceCondition() != null) {
-      //
-      // Include the condition title in the name to help distinguish
-      // it from other roles that might have no or different conditions
-      //
-      return String.format("%s (%s)", role.role(), binding.getCondition().getTitle());
-    }
-    else {
-      return role.role();
-    }
-  }
-
   public AssetInventoryRepository(
     @NotNull Executor executor,
     @NotNull DirectoryGroupsClient groupsClient,
@@ -165,7 +149,7 @@ public class AssetInventoryRepository extends ProjectRoleRepository {
           .fromJitEligibleRoleBinding(projectId, binding)
           .map(projectRole -> new Entitlement<>(
             projectRole,
-            createEntitlementName(binding, projectRole),
+            projectRole.role(),
             ActivationType.JIT)))
         .filter(projectRole -> projectRole.isPresent())
         .map(Optional::get)
@@ -187,7 +171,7 @@ public class AssetInventoryRepository extends ProjectRoleRepository {
           .fromMpaEligibleRoleBinding(projectId, binding)
           .map(projectRole -> new Entitlement<>(
             projectRole,
-            createEntitlementName(binding, projectRole),
+            projectRole.role(),
             ActivationType.MPA)))
         .filter(role -> role.isPresent())
         .map(Optional::get)

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/PolicyAnalyzerRepository.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/PolicyAnalyzerRepository.java
@@ -187,6 +187,9 @@ public class PolicyAnalyzerRepository extends ProjectRoleRepository {
     // conditional and have a special condition that serves
     // as marker.
     //
+    // Ignore eligible role bindings that have an extra
+    // resource condition, we don't support these.
+    //
     Set<Entitlement<ProjectRole>> jitEligible;
     if (typesToInclude.contains(ActivationType.JIT)) {
       jitEligible = findRoleBindings(
@@ -194,6 +197,7 @@ public class PolicyAnalyzerRepository extends ProjectRoleRepository {
         condition -> ProjectRole.EligibilityCondition
           .parse(condition)
           .filter(ProjectRole.EligibilityCondition::isJitEligible)
+          .filter(c -> c.resourceCondition() == null)
           .isPresent(),
         evalResult -> "CONDITIONAL".equalsIgnoreCase(evalResult))
         .stream()
@@ -214,6 +218,9 @@ public class PolicyAnalyzerRepository extends ProjectRoleRepository {
     // conditional and have a special condition that serves
     // as marker.
     //
+    // Ignore eligible role bindings that have an extra
+    // resource condition, we don't support these.
+    //
     Set<Entitlement<ProjectRole>> mpaEligible;
     if (typesToInclude.contains(ActivationType.MPA)) {
       mpaEligible = findRoleBindings(
@@ -221,6 +228,7 @@ public class PolicyAnalyzerRepository extends ProjectRoleRepository {
         condition -> ProjectRole.EligibilityCondition
           .parse(condition)
           .filter(ProjectRole.EligibilityCondition::isMpaEligible)
+          .filter(c -> c.resourceCondition() == null)
           .isPresent(),
         evalResult -> "CONDITIONAL".equalsIgnoreCase(evalResult))
         .stream()
@@ -253,9 +261,15 @@ public class PolicyAnalyzerRepository extends ProjectRoleRepository {
     // the condition evaluates to TRUE (indicating it's still
     // valid).
     //
+    // Ignore eligible role bindings that have an extra
+    // resource condition, we don't support these.
+    //
     var currentActivations = findRoleBindings(
         analysisResult,
-        condition -> ProjectRole.ActivationCondition.parse(condition).isPresent(),
+        condition -> ProjectRole.ActivationCondition
+          .parse(condition)
+          .filter(c -> c.resourceCondition() == null)
+          .isPresent(),
         evalResult -> "TRUE".equalsIgnoreCase(evalResult))
       .stream()
       .map(conditionalBinding -> ProjectRole.fromActivationRoleBinding(
@@ -272,7 +286,10 @@ public class PolicyAnalyzerRepository extends ProjectRoleRepository {
     //
     var expiredActivations = findRoleBindings(
         analysisResult,
-      condition -> ProjectRole.ActivationCondition.parse(condition).isPresent(),
+        condition -> ProjectRole.ActivationCondition
+          .parse(condition)
+          .filter(c -> c.resourceCondition() == null)
+          .isPresent(),
         evalResult -> "FALSE".equalsIgnoreCase(evalResult))
       .stream()
       .map(conditionalBinding -> ProjectRole.fromActivationRoleBinding(

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectRole.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectRole.java
@@ -159,8 +159,7 @@ public class ProjectRole extends EntitlementId {
   ) {
     return EligibilityCondition.parse(binding.getCondition())
       .filter(EligibilityCondition::isJitEligible)
-      .filter(c -> c.resourceCondition() == null)
-      .map(c -> new ProjectRole(projectId, binding.getRole()));
+      .map(c -> new ProjectRole(projectId, binding.getRole(), c.resourceCondition()));
   }
 
   /**
@@ -177,8 +176,7 @@ public class ProjectRole extends EntitlementId {
   ) {
     return EligibilityCondition.parse(binding.getCondition())
       .filter(EligibilityCondition::isMpaEligible)
-      .filter(c -> c.resourceCondition() == null)
-      .map(c -> new ProjectRole(projectId, binding.getRole()));
+      .map(c -> new ProjectRole(projectId, binding.getRole(), c.resourceCondition()));
   }
 
   /**
@@ -194,9 +192,8 @@ public class ProjectRole extends EntitlementId {
     @NotNull Binding binding
   ) {
     return ActivationCondition.parse(binding.getCondition())
-      .filter(c -> c.resourceCondition() == null)
       .map(c -> new ActivatedProjectRole(
-        new ProjectRole(projectId, binding.getRole()),
+        new ProjectRole(projectId, binding.getRole(), c.resourceCondition()),
         c.toActivation()));
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectRoleActivator.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectRoleActivator.java
@@ -101,6 +101,10 @@ public class ProjectRoleActivator extends EntitlementActivator<
           .setDescription(bindingDescription)
           .setExpression(condition.toString()));
 
+      //
+      // NB. To limit clutter, purge existing temporary bindings for the
+      // same user and role, even if their resource condition differs.
+      //
       this.resourceManagerClient.addProjectIamBinding(
         projectId,
         binding,

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/clients/ResourceManagerClient.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/clients/ResourceManagerClient.java
@@ -159,6 +159,8 @@ public class ResourceManagerClient {
             && b.getCondition() != null
             && TemporaryIamCondition.isTemporaryAccessCondition(b.getCondition().getExpression());
 
+          //TODO: only purge when expired
+
           var nonObsoleteBindings =
             policy.getBindings().stream()
               .filter(isObsolete.negate())

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/clients/ResourceManagerClient.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/clients/ResourceManagerClient.java
@@ -159,8 +159,6 @@ public class ResourceManagerClient {
             && b.getCondition() != null
             && TemporaryIamCondition.isTemporaryAccessCondition(b.getCondition().getExpression());
 
-          //TODO: only purge when expired
-
           var nonObsoleteBindings =
             policy.getBindings().stream()
               .filter(isObsolete.negate())

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/LogEvents.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/LogEvents.java
@@ -25,7 +25,7 @@ public class LogEvents {
   public static final String API_LIST_PROJECTS = "api.listProjects";
   public static final String API_LIST_ROLES = "api.listEligibleRoles";
   public static final String API_LIST_PEERS = "api.listPeers";
-  public static final String API_ACTIVATE_ROLE = "api.activateRole";
+  public static final String API_ACTIVATE_ROLE = "api.activateRole"; // TODO: include resource condition
   public static final String API_REQUEST_ROLE = "api.requestRole";
   public static final String API_GET_REQUEST = "api.getActivationRequest";
   public static final String API_HEALTH = "api.checkHealth";

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/AbstractActivationAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/AbstractActivationAction.java
@@ -33,6 +33,7 @@ import com.google.solutions.jitaccess.web.TokenObfuscator;
 import jakarta.enterprise.inject.Instance;
 import jakarta.ws.rs.core.UriInfo;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -136,6 +137,7 @@ public abstract class AbstractActivationAction extends AbstractAction {
       public final @NotNull String projectId;
       public final @NotNull String id;
       public final @NotNull String name;
+      public final @Nullable String resourceCondition;
       public final @NotNull ActivationStatus status;
       public final long startTime;
       public final long endTime;
@@ -153,6 +155,7 @@ public abstract class AbstractActivationAction extends AbstractAction {
         this.projectId = role.projectId().id();
         this.id = role.id();
         this.name = role.role();
+        this.resourceCondition = role.resourceCondition();
         this.status = status;
         this.startTime = startTime.getEpochSecond();
         this.endTime = endTime.getEpochSecond();

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ApproveActivationRequestAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ApproveActivationRequestAction.java
@@ -178,16 +178,18 @@ public class ApproveActivationRequestAction extends AbstractActivationAction {
 
       assert request.entitlements().size() == 1;
 
+      var role = request
+        .entitlements()
+        .stream()
+        .findFirst()
+        .get();
+
       this.properties.put("APPROVER", approver.email);
       this.properties.put("BENEFICIARY", request.requestingUser());
       this.properties.put("REVIEWERS", request.reviewers());
       this.properties.put("PROJECT_ID", projectId);
-      this.properties.put("ROLE", request
-        .entitlements()
-        .stream()
-        .findFirst()
-        .get()
-        .role());
+      this.properties.put("ROLE", role.role());
+      this.properties.put("RESOURCE_CONDITION", role.resourceCondition());
       this.properties.put("START_TIME", request.startTime());
       this.properties.put("END_TIME", request.endTime());
       this.properties.put("JUSTIFICATION", request.justification());

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ApproveActivationRequestAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ApproveActivationRequestAction.java
@@ -22,6 +22,7 @@
 package com.google.solutions.jitaccess.web.actions;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.AccessException;
 import com.google.solutions.jitaccess.core.util.Exceptions;
@@ -189,7 +190,7 @@ public class ApproveActivationRequestAction extends AbstractActivationAction {
       this.properties.put("REVIEWERS", request.reviewers());
       this.properties.put("PROJECT_ID", projectId);
       this.properties.put("ROLE", role.role());
-      this.properties.put("RESOURCE_CONDITION", role.resourceCondition());
+      this.properties.put("RESOURCE_CONDITION", Strings.nullToEmpty(role.resourceCondition()));
       this.properties.put("START_TIME", request.startTime());
       this.properties.put("END_TIME", request.endTime());
       this.properties.put("JUSTIFICATION", request.justification());

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ListRolesAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ListRolesAction.java
@@ -75,6 +75,7 @@ public class ListRolesAction extends AbstractAction {
               return new ResponseEntity.Item(
                 ent.id().id(),
                 ent.name(),
+                ent.id().resourceCondition(),
                 ent.activationType(),
                 ActivationStatus.ACTIVE,
                 currentActivation.validity().end().getEpochSecond());
@@ -83,6 +84,7 @@ public class ListRolesAction extends AbstractAction {
               return new ResponseEntity.Item(
                 ent.id().id(),
                 ent.name(),
+                ent.id().resourceCondition(),
                 ent.activationType(),
                 ActivationStatus.INACTIVE,
                 null);
@@ -121,6 +123,7 @@ public class ListRolesAction extends AbstractAction {
     public static class Item {
       public final @NotNull String id;
       public final @NotNull String name;
+      public final @Nullable String resourceCondition;
       public final @NotNull ActivationType activationType;
       public final @NotNull ActivationStatus status;
       public final Long /* optional */ validUntil;
@@ -128,12 +131,14 @@ public class ListRolesAction extends AbstractAction {
       public Item(
         @NotNull String id,
         @NotNull String name,
+        @Nullable String resourceCondition,
         @NotNull ActivationType activationType,
         @NotNull ActivationStatus status,
         Long validUntil) {
 
         this.id = id;
         this.name = name;
+        this.resourceCondition = resourceCondition;
         this.activationType = activationType;
         this.status = status;
         this.validUntil = validUntil;

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestActivationAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestActivationAction.java
@@ -22,6 +22,7 @@
 package com.google.solutions.jitaccess.web.actions;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.solutions.jitaccess.core.AccessDeniedException;
 import com.google.solutions.jitaccess.core.AccessException;
 import com.google.solutions.jitaccess.core.util.Exceptions;
@@ -277,7 +278,7 @@ public class RequestActivationAction extends AbstractActivationAction {
       this.properties.put("REVIEWERS", request.reviewers());
       this.properties.put("PROJECT_ID", projectId);
       this.properties.put("ROLE", role.role());
-      this.properties.put("RESOURCE_CONDITION", role.resourceCondition());
+      this.properties.put("RESOURCE_CONDITION", Strings.nullToEmpty(role.resourceCondition()));
       this.properties.put("START_TIME", request.startTime());
       this.properties.put("END_TIME", request.endTime());
       this.properties.put("REQUEST_EXPIRY_TIME", requestExpiryTime);

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestActivationAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestActivationAction.java
@@ -267,15 +267,17 @@ public class RequestActivationAction extends AbstractActivationAction {
 
       assert request.entitlements().size() == 1;
 
-      this.properties.put("BENEFICIARY", request.requestingUser());
-      this.properties.put("REVIEWERS", request.reviewers());
-      this.properties.put("PROJECT_ID", projectId);
-      this.properties.put("ROLE", request
+      var role = request
         .entitlements()
         .stream()
         .findFirst()
-        .get()
-        .role());
+        .get();
+
+      this.properties.put("BENEFICIARY", request.requestingUser());
+      this.properties.put("REVIEWERS", request.reviewers());
+      this.properties.put("PROJECT_ID", projectId);
+      this.properties.put("ROLE", role.role());
+      this.properties.put("RESOURCE_CONDITION", role.resourceCondition());
       this.properties.put("START_TIME", request.startTime());
       this.properties.put("END_TIME", request.endTime());
       this.properties.put("REQUEST_EXPIRY_TIME", requestExpiryTime);

--- a/sources/src/main/resources/META-INF/resources/index.html
+++ b/sources/src/main/resources/META-INF/resources/index.html
@@ -358,7 +358,7 @@
                                 item.id,
                                 [
                                     { text: item.name },
-                                    { text: item.resourceCondition, class: "condition", maxLength: 30 },
+                                    { text: item.resourceCondition ?? "-", class: "condition", maxLength: 30 },
                                     { text: this.activationTypeCaptions[item.activationType] ?? item.activationType },
                                     { text: (this.statusCaptions[item.status] ?? item.status) + 
                                             (item.validUntil == null ? "" : ` (${Math.floor((item.validUntil * 1000 - new Date()) / (60*1000))} minutes left)`), 
@@ -633,7 +633,7 @@
                             [
                                 { text: item.projectId },
                                 { text: item.name },
-                                { text: item.resourceCondition, class: "condition", maxLength: 30 },
+                                { text: item.resourceCondition ?? "-", class: "condition", maxLength: 30 },
                                 { text: this.statusCaptions[item.status] ?? item.status, 
                                   class: item.status === "ACTIVE" ? "activated" : null }
                             ],

--- a/sources/src/main/resources/META-INF/resources/index.html
+++ b/sources/src/main/resources/META-INF/resources/index.html
@@ -27,23 +27,24 @@
               <div class="mdc-data-table__table-container">
                 <table class="mdc-data-table__table">
                   <thead>
-                    <tr class="mdc-data-table__header-row">
-                      <th class="mdc-data-table__header-cell mdc-data-table__header-cell--checkbox" role="columnheader" scope="col">
-                        <div class="mdc-checkbox mdc-data-table__header-row-checkbox mdc-checkbox--selected">
-                          <input type="checkbox" class="mdc-checkbox__native-control" aria-label="Toggle all rows"/>
-                          <div class="mdc-checkbox__background">
-                            <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                              <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
-                            </svg>
-                            <div class="mdc-checkbox__mixedmark"></div>
-                          </div>
-                          <div class="mdc-checkbox__ripple"></div>
-                        </div>
-                      </th>
-                      <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Role</th>
-                      <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Requirements</th>
-                      <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Status</th>
-                    </tr>
+                      <tr class="mdc-data-table__header-row">
+                          <th class="mdc-data-table__header-cell mdc-data-table__header-cell--checkbox" role="columnheader" scope="col">
+                              <div class="mdc-checkbox mdc-data-table__header-row-checkbox mdc-checkbox--selected">
+                                  <input type="checkbox" class="mdc-checkbox__native-control" aria-label="Toggle all rows" />
+                                  <div class="mdc-checkbox__background">
+                                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                                          <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                                      </svg>
+                                      <div class="mdc-checkbox__mixedmark"></div>
+                                  </div>
+                                  <div class="mdc-checkbox__ripple"></div>
+                              </div>
+                          </th>
+                          <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Role</th>
+                          <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Condition</th>
+                          <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Requirements</th>
+                          <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Status</th>
+                      </tr>
                   </thead>
                   <tbody class="mdc-data-table__content">
                   </tbody>
@@ -146,6 +147,7 @@
                         <tr class="mdc-data-table__header-row">
                           <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Project</th>
                           <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Role</th>
+                          <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Condition</th>
                           <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Status</th>
                         </tr>
                       </thead>
@@ -356,6 +358,7 @@
                                 item.id,
                                 [
                                     { text: item.name },
+                                    { text: item.resourceCondition, class: "condition", maxLength: 30 },
                                     { text: this.activationTypeCaptions[item.activationType] ?? item.activationType },
                                     { text: (this.statusCaptions[item.status] ?? item.status) + 
                                             (item.validUntil == null ? "" : ` (${Math.floor((item.validUntil * 1000 - new Date()) / (60*1000))} minutes left)`), 
@@ -630,6 +633,7 @@
                             [
                                 { text: item.projectId },
                                 { text: item.name },
+                                { text: item.resourceCondition, class: "condition", maxLength: 30 },
                                 { text: this.statusCaptions[item.status] ?? item.status, 
                                   class: item.status === "ACTIVE" ? "activated" : null }
                             ],

--- a/sources/src/main/resources/META-INF/resources/model.js
+++ b/sources/src/main/resources/META-INF/resources/model.js
@@ -321,6 +321,7 @@ class DebugModel extends Model {
                 projectId: projectId,
                 id: id,
                 name: `Name of ${id}`,
+                resourceCondition: 'test()',
                 status: status,
                 startTime: Math.floor(Date.now() / 1000),
                 endTime: Math.floor(Date.now() / 1000) + activationTimeout * 60
@@ -359,6 +360,7 @@ class DebugModel extends Model {
                 entitlements: Array.from({ length: setting }, (e, i) => ({
                     id: `${projectId}:roles/simulated-role-${i}`,
                     name: `roles/simulated-role-${i}`,
+                    resourceCondition: 'test()',
                     activationType: activationTypes[i % activationTypes.length],
                     status: statuses[i % statuses.length]
                 }))

--- a/sources/src/main/resources/META-INF/resources/styles.css
+++ b/sources/src/main/resources/META-INF/resources/styles.css
@@ -14,7 +14,13 @@ h1, h2 {
     border-radius: 4px;
     padding: 4px;
     display: inline;
-}    
+}
+
+.condition {
+    font-family: Courier New, Courier, monospace;
+    font-size: 11px;
+    color: #9e9e9e;
+}
 
 .jit-title {
     color: #006CBE;

--- a/sources/src/main/resources/META-INF/resources/view.js
+++ b/sources/src/main/resources/META-INF/resources/view.js
@@ -39,7 +39,14 @@ mdc.dataTable.MDCDataTable.prototype.addRow = function(id, columns, showCheckbox
     let first = true;
     columns.forEach((value) => {
         const div = $("<div></div>");
-        div.text(value.text);
+
+        if (value.text && value.maxLength && value.text.length > value.maxLength) {
+            div.prop('title', value.text);
+            div.text(value.text.substring(0, value.maxLength) + '...');
+        }
+        else {
+            div.text(value.text);
+        }
         if (value.class) {
             div.attr("class", value.class);
         }

--- a/sources/src/main/resources/notifications/ActivationApproved.html
+++ b/sources/src/main/resources/notifications/ActivationApproved.html
@@ -25,6 +25,12 @@
                         </li>
                         <li>
                             <div style="display: flex; flow-direction: row;">
+                                <div style="color: #5F6368; font-family: Roboto, Arial, sans-serif; font-style: normal; font-size: 16px; line-height: 24px; letter-spacing: 0.1px; font-weight: 400; min-width: 174px;">Resource Condition</div>
+                                <div style="color: #3c4043; font-family: Roboto, Arial, sans-serif; font-style: normal; font-size: 16px; line-height: 24px; letter-spacing: 0.1px; font-weight: 400;"><code>{{RESOURCE_CONDITION}}</code></div>
+                            </div>
+                        </li>
+                        <li>
+                            <div style="display: flex; flow-direction: row;">
                                 <div style="color: #5F6368; font-family: Roboto, Arial, sans-serif; font-style: normal; font-size: 16px; line-height: 24px; letter-spacing: 0.1px; font-weight: 400; min-width: 174px;">Start time</div>
                                 <div style="color: #3c4043; font-family: Roboto, Arial, sans-serif; font-style: normal; font-size: 16px; line-height: 24px; letter-spacing: 0.1px; font-weight: 400;">{{START_TIME}}</div>
                             </div>

--- a/sources/src/main/resources/notifications/RequestActivation.html
+++ b/sources/src/main/resources/notifications/RequestActivation.html
@@ -33,6 +33,12 @@
                         </li>
                         <li>
                             <div style="display: flex; flow-direction: row;">
+                                <div style="color: #5F6368; font-family: Roboto, Arial, sans-serif; font-style: normal; font-size: 16px; line-height: 24px; letter-spacing: 0.1px; font-weight: 400; min-width: 174px;">Resource Condition</div>
+                                <div style="color: #3c4043; font-family: Roboto, Arial, sans-serif; font-style: normal; font-size: 16px; line-height: 24px; letter-spacing: 0.1px; font-weight: 400;"><code>{{RESOURCE_CONDITION}}</code></div>
+                            </div>
+                        </li>
+                        <li>
+                            <div style="display: flex; flow-direction: row;">
                                 <div style="color: #5F6368; font-family: Roboto, Arial, sans-serif; font-style: normal; font-size: 16px; line-height: 24px; letter-spacing: 0.1px; font-weight: 400; min-width: 174px;">Start time</div>
                                 <div style="color: #3c4043; font-family: Roboto, Arial, sans-serif; font-style: normal; font-size: 16px; line-height: 24px; letter-spacing: 0.1px; font-weight: 400;">{{START_TIME}}</div>
                             </div>

--- a/sources/src/main/resources/notifications/RequestActivation.html
+++ b/sources/src/main/resources/notifications/RequestActivation.html
@@ -70,7 +70,7 @@
                 </div>
                 <div style="font-family: Roboto, Arial, sans-serif; font-style: normal; font-weight: 700; font-size: 14px; line-height: 24px; letter-spacing: 0.1px; color: #3c4043;">Why am I seeing this?</div>
                 <div style="font-family: Roboto, Arial, sans-serif; font-style: normal; font-weight: 400; font-size: 14px; line-height: 24px; letter-spacing: 0.1px; color: #3c4043;">
-                    To actviate the role <code>{{ROLE}}</code> on <code>{{PROJECT_ID}}</code>, {{BENEFICIARY}} requires approval from another user.
+                    To activate the role <code>{{ROLE}}</code> on <code>{{PROJECT_ID}}</code>, {{BENEFICIARY}} requires approval from another user.
                     You are qualified to approve their request because you also have <code>{{ROLE}}</code> access to <code>{{PROJECT_ID}}</code>.
                 </div>
             </div>

--- a/sources/src/test/java/com/google/solutions/jitaccess/cel/TestTemporaryIamCondition.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/cel/TestTemporaryIamCondition.java
@@ -129,7 +129,16 @@ public class TestTemporaryIamCondition {
   }
 
   @Test
-  public void whenExpressionContainsMoreThanTemporaryCondition_ThenIsTemporaryAccessConditionReturnsTrue() {
+  public void whenExpressionHasExcessParentheses_ThenIsTemporaryAccessConditionReturnsTrue() {
+    var clause =
+      "  (((request.time >= timestamp(\"2020-01-01T00:00:00Z\") && "
+        + "request.time < timestamp(\"2020-01-01T00:05:00Z\"))))  ";
+
+    assertTrue(TemporaryIamCondition.isTemporaryAccessCondition(clause));
+  }
+
+  @Test
+  public void whenExpressionContainsMoreThanTemporaryCondition_ThenIsTemporaryAccessConditionReturnsFalse() {
     var clause =
       "  (request.time >= timestamp(\"2020-01-01T00:00:00Z\") && "
         + "request.time < timestamp(\"2020-01-01T00:05:00Z\")) && foo='foo' ";

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestProjectRole.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestProjectRole.java
@@ -49,10 +49,23 @@ public class TestProjectRole {
       "iam:project-1:role/sample",
       new ProjectRole(SAMPLE_PROJECT, "role/sample").toString());
     assertEquals(
-      "iam:project-1:role/sample[condition]",
-      new ProjectRole(SAMPLE_PROJECT, "role/sample", "condition").toString());
+      "iam:project-1:role/sample:cmVzb3VyY2UubmFtZT09J2Zvbyc=",
+      new ProjectRole(SAMPLE_PROJECT, "role/sample", "resource.name=='foo'").toString());
   }
 
+  // -------------------------------------------------------------------------
+  // id.
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void idContainsResourceAndRole() {
+    assertEquals(
+      "project-1:role/sample",
+      new ProjectRole(SAMPLE_PROJECT, "role/sample").id());
+    assertEquals(
+      "project-1:role/sample:cmVzb3VyY2UubmFtZT09J2Zvbyc=",
+      new ProjectRole(SAMPLE_PROJECT, "role/sample", "resource.name=='foo'").id());
+  }
 
   // -------------------------------------------------------------------------
   // equals.
@@ -129,9 +142,12 @@ public class TestProjectRole {
   }
 
   @Test
-  public void whenIdValid_ThenFromIdReturns() {
-    var role = new ProjectRole(SAMPLE_PROJECT, "roles/test");
-    assertEquals(role, ProjectRole.fromId(role.id()));
+  public void whenIdValid_ThenFromIdSucceeds() {
+    var roleWithoutCondition = new ProjectRole(SAMPLE_PROJECT, "roles/test");
+    var roleWithCondition = new ProjectRole(SAMPLE_PROJECT, "roles/test", "resource.name=='foo'");
+
+    assertEquals(roleWithoutCondition, ProjectRole.fromId(roleWithoutCondition.id()));
+    assertEquals(roleWithCondition, ProjectRole.fromId(roleWithCondition.id()));
   }
 
   // -------------------------------------------------------------------------

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestProjectRole.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestProjectRole.java
@@ -45,8 +45,12 @@ public class TestProjectRole {
 
   @Test
   public void toStringReturnsResourceAndRole() {
-    var role = new ProjectRole(SAMPLE_PROJECT, "role/sample");
-    assertEquals("iam:project-1:role/sample", role.toString());
+    assertEquals(
+      "iam:project-1:role/sample",
+      new ProjectRole(SAMPLE_PROJECT, "role/sample").toString());
+    assertEquals(
+      "iam:project-1:role/sample[condition]",
+      new ProjectRole(SAMPLE_PROJECT, "role/sample", "condition").toString());
   }
 
 
@@ -89,6 +93,16 @@ public class TestProjectRole {
   public void whenRolesDiffer_ThenEqualsReturnsFalse() {
     var role1 = new ProjectRole(new ProjectId("project-1"), "roles/test");
     var role2 = new ProjectRole(new ProjectId("project-1"), "roles/other");
+
+    assertFalse(role1.equals(role2));
+    assertFalse(role1.equals((Object) role2));
+    assertNotEquals(role1.hashCode(), role2.hashCode());
+  }
+
+  @Test
+  public void whenResourceConditionsDiffer_ThenEqualsReturnsFalse() {
+    var role1 = new ProjectRole(new ProjectId("project-1"), "roles/test");
+    var role2 = new ProjectRole(new ProjectId("project-2"), "roles/test", "true || false");
 
     assertFalse(role1.equals(role2));
     assertFalse(role1.equals((Object) role2));


### PR DESCRIPTION
* Extend parsing logic to extract resource condition clauses from IAM conditions. Clauses can be in any order, for ex:

   - `has({}.jitAccessConstraint) && resource.name==...'`
   - `resource.name=='...' && has({}.mpaAccessConstraint) && resource.type=='...'`

* Surface eligible roles with resource conditions to user

Insipired by #87