### PR TITLE
b/339555965 Check justification on submitting MPA request

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/EntitlementActivator.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/EntitlementActivator.java
@@ -106,6 +106,11 @@ public abstract class EntitlementActivator<
       startTime.isAfter(Instant.now().minus(Duration.ofMinutes(1))),
       "Start time must not be in the past");
 
+    //
+    // Check that the justification is ok.
+    //
+    policy.checkJustification(requestingUserContext.user(), justification);
+
     var request = new MpaRequest<>(
       ActivationId.newId(ActivationType.MPA),
       requestingUserContext.user(),
@@ -134,8 +139,6 @@ public abstract class EntitlementActivator<
     @NotNull JitActivationRequest<TEntitlementId> request
   ) throws AccessException, AlreadyExistsException, IOException
   {
-    Preconditions.checkNotNull(policy, "policy");
-
     //
     // Check that the justification is ok.
     //

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/TestEntitlementActivator.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/TestEntitlementActivator.java
@@ -140,6 +140,31 @@ public class TestEntitlementActivator {
   // -------------------------------------------------------------------------
 
   @Test
+  public void whenJustificationInvalid_ThenCreateMpaRequestThrowsException() throws Exception {
+    var justificationPolicy = Mockito.mock(JustificationPolicy.class);
+
+    Mockito.doThrow(new InvalidJustificationException("mock"))
+      .when(justificationPolicy)
+      .checkJustification(eq(SAMPLE_REQUESTING_USER), anyString());
+
+    var activator = new SampleActivator(
+      Mockito.mock(Catalog.class),
+      justificationPolicy);
+
+    var requestingUserContext = new UserContext(SAMPLE_REQUESTING_USER);
+
+    assertThrows(
+      InvalidJustificationException.class,
+      () -> activator.createMpaRequest(
+        requestingUserContext,
+        Set.of(new SampleEntitlementId("cat", "1")),
+        Set.of(SAMPLE_APPROVING_USER),
+        "justification",
+        Instant.now(),
+        Duration.ofMinutes(5)));
+  }
+
+  @Test
   public void  whenUserNotAllowedToRequest_ThenCreateMpaRequestThrowsException() throws Exception {
     var catalog = Mockito.mock(Catalog.class);
     var requestingUserContext = new UserContext(SAMPLE_REQUESTING_USER);
@@ -266,10 +291,6 @@ public class TestEntitlementActivator {
   public void whenJustificationInvalid_ThenApproveMpaRequestThrowsException() throws Exception {
     var justificationPolicy = Mockito.mock(JustificationPolicy.class);
 
-    Mockito.doThrow(new InvalidJustificationException("mock"))
-      .when(justificationPolicy)
-      .checkJustification(eq(SAMPLE_REQUESTING_USER), anyString());
-
     var activator = new SampleActivator(
       Mockito.mock(Catalog.class),
       justificationPolicy);
@@ -282,6 +303,10 @@ public class TestEntitlementActivator {
       "justification",
       Instant.now(),
       Duration.ofMinutes(5));
+
+    Mockito.doThrow(new InvalidJustificationException("mock"))
+      .when(justificationPolicy)
+      .checkJustification(eq(SAMPLE_REQUESTING_USER), anyString());
 
     var approvingUserContext = new UserContext(SAMPLE_APPROVING_USER);
     assertThrows(


### PR DESCRIPTION
Check the justification on submit, in addition to checking it on approval. Security-wise, this doesn't make a difference, but it improves the UX.