### PR TITLE
b/339726909 Include resource condition in logs

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/ActivationRequest.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/ActivationRequest.java
@@ -130,7 +130,7 @@ public abstract class ActivationRequest<TEntitlementId extends EntitlementId> {
     return String.format(
       "[%s] entitlements=%s, startTime=%s, duration=%s, justification=%s",
       this.id,
-      this.entitlements.stream().map(e -> e.toString()).collect(Collectors.joining(",")),
+      this.entitlements.stream().map(e -> e.id()).collect(Collectors.joining(",")),
       this.startTime,
       this.duration,
       this.justification);

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/EntitlementId.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/EntitlementId.java
@@ -49,7 +49,7 @@ public abstract class EntitlementId implements Comparable<EntitlementId> {
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.catalog(), this.id());
+    return String.format("[%s] %s", this.catalog(), this.id());
   }
 
   @Override

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectRole.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/catalog/project/ProjectRole.java
@@ -117,6 +117,25 @@ public class ProjectRole extends EntitlementId {
     }
   }
 
+  @Override
+  public String toString() {
+    if (this.resourceCondition != null) {
+      return String.format(
+        "[%s] %s on %s (condition: %s)",
+        this.catalog(),
+        this.role,
+        this.projectId,
+        this.resourceCondition);
+    }
+    else {
+      return String.format(
+        "[%s] %s on %s",
+        this.catalog(),
+        this.role,
+        this.projectId);
+    }
+  }
+
   //---------------------------------------------------------------------------
   // Factory methods.
   //---------------------------------------------------------------------------

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ApproveActivationRequestAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/ApproveActivationRequestAction.java
@@ -93,7 +93,7 @@ public class ApproveActivationRequestAction extends AbstractActivationAction {
     }
 
     assert activationRequest.entitlements().size() == 1;
-    var roleBinding = activationRequest
+    var entitlement = activationRequest
       .entitlements()
       .stream()
       .findFirst()
@@ -109,10 +109,10 @@ public class ApproveActivationRequestAction extends AbstractActivationAction {
       //
       for (var service : this.notificationServices) {
         service.sendNotification(new ActivationApprovedNotification(
-          roleBinding.projectId(),
+          entitlement.projectId(),
           activationRequest,
           iapPrincipal.email(),
-          createActivationRequestUrl(uriInfo, roleBinding.projectId(), activationToken)));
+          createActivationRequestUrl(uriInfo, entitlement.projectId(), activationToken)));
       }
 
       //
@@ -122,10 +122,9 @@ public class ApproveActivationRequestAction extends AbstractActivationAction {
         .newInfoEntry(
           LogEvents.API_ACTIVATE_ROLE,
           String.format(
-            "User %s approved role '%s' on '%s' for %s",
+            "User %s approved '%s' for %s",
             iapPrincipal.email(),
-            roleBinding.role(),
-            roleBinding.projectId().getFullResourceName(),
+            entitlement,
             activationRequest.requestingUser()))
         .addLabels(le -> addLabels(le, activationRequest))
         .write();
@@ -140,10 +139,9 @@ public class ApproveActivationRequestAction extends AbstractActivationAction {
         .newErrorEntry(
           LogEvents.API_ACTIVATE_ROLE,
           String.format(
-            "User %s failed to activate role '%s' on '%s' for %s: %s",
+            "User %s failed to activate '%s' for %s: %s",
             iapPrincipal.email(),
-            roleBinding.role(),
-            roleBinding.projectId().getFullResourceName(),
+            entitlement,
             activationRequest.requestingUser(),
             Exceptions.getFullMessage(e)))
         .addLabels(le -> addLabels(le, activationRequest))

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestActivationAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestActivationAction.java
@@ -111,10 +111,10 @@ public class RequestActivationAction extends AbstractActivationAction {
 
     var userContext = this.catalog.createContext(iapPrincipal.email());
     var projectId = new ProjectId(projectIdString);
-    var role = ProjectRole.fromId(request.entitlementId);
+    var entitlement = ProjectRole.fromId(request.entitlementId);
 
     Preconditions.checkArgument(
-      role.projectId().equals(projectId),
+      entitlement.projectId().equals(projectId),
       "The project ID does not match the current project");
 
     //
@@ -126,7 +126,7 @@ public class RequestActivationAction extends AbstractActivationAction {
     try {
       activationRequest = this.activator.createMpaRequest(
         userContext,
-        Set.of(role),
+        Set.of(entitlement),
         request.peers.stream().map(email -> new UserId(email)).collect(Collectors.toSet()),
         request.justification,
         Instant.now().truncatedTo(ChronoUnit.SECONDS),
@@ -137,10 +137,9 @@ public class RequestActivationAction extends AbstractActivationAction {
         .newErrorEntry(
           LogEvents.API_ACTIVATE_ROLE,
           String.format(
-            "Received invalid activation request from user '%s' for role '%s' on '%s': %s",
+            "Received invalid activation request from user '%s' for '%s': %s",
             iapPrincipal.email(),
-            role,
-            projectId.getFullResourceName(),
+            entitlement,
             Exceptions.getFullMessage(e)))
         .addLabels(le -> addLabels(le, projectId))
         .addLabels(le -> addLabels(le, e))
@@ -200,8 +199,8 @@ public class RequestActivationAction extends AbstractActivationAction {
           String.format(
             "User %s requested role '%s' on '%s' for %d minutes",
             iapPrincipal.email(),
-            role.role(),
-            role.projectId().getFullResourceName(),
+            entitlement.role(),
+            entitlement.projectId().getFullResourceName(),
             requestedRoleBindingDuration.toMinutes()))
         .addLabels(le -> addLabels(le, projectId))
         .addLabels(le -> addLabels(le, activationRequest))
@@ -219,12 +218,12 @@ public class RequestActivationAction extends AbstractActivationAction {
           String.format(
             "User %s failed to request role '%s' on '%s' for %d minutes: %s",
             iapPrincipal.email(),
-            role.role(),
-            role.projectId().getFullResourceName(),
+            entitlement.role(),
+            entitlement.projectId().getFullResourceName(),
             requestedRoleBindingDuration.toMinutes(),
             Exceptions.getFullMessage(e)))
         .addLabels(le -> addLabels(le, projectId))
-        .addLabels(le -> addLabels(le, role))
+        .addLabels(le -> addLabels(le, entitlement))
         .addLabels(le -> addLabels(le, e))
         .addLabel("justification", request.justification)
         .write();

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestActivationAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestActivationAction.java
@@ -197,10 +197,9 @@ public class RequestActivationAction extends AbstractActivationAction {
         .newInfoEntry(
           LogEvents.API_REQUEST_ROLE,
           String.format(
-            "User %s requested role '%s' on '%s' for %d minutes",
+            "User %s requested '%s' for %d minutes",
             iapPrincipal.email(),
-            entitlement.role(),
-            entitlement.projectId().getFullResourceName(),
+            entitlement,
             requestedRoleBindingDuration.toMinutes()))
         .addLabels(le -> addLabels(le, projectId))
         .addLabels(le -> addLabels(le, activationRequest))
@@ -216,10 +215,9 @@ public class RequestActivationAction extends AbstractActivationAction {
         .newErrorEntry(
           LogEvents.API_REQUEST_ROLE,
           String.format(
-            "User %s failed to request role '%s' on '%s' for %d minutes: %s",
+            "User %s failed to request '%s' for %d minutes: %s",
             iapPrincipal.email(),
-            entitlement.role(),
-            entitlement.projectId().getFullResourceName(),
+            entitlement,
             requestedRoleBindingDuration.toMinutes(),
             Exceptions.getFullMessage(e)))
         .addLabels(le -> addLabels(le, projectId))

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestAndSelfApproveAction.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/actions/RequestAndSelfApproveAction.java
@@ -123,12 +123,11 @@ public class RequestAndSelfApproveAction extends AbstractActivationAction {
         .newInfoEntry(
           LogEvents.API_ACTIVATE_ROLE,
           String.format(
-            "User %s activated roles %s on '%s' for themselves for %d minutes",
+            "User %s activated %s for themselves for %d minutes",
             iapPrincipal.email(),
             activationRequest.entitlements().stream()
-              .map(ent -> String.format("'%s'", ent.role()))
+              .map(ent -> String.format("'%s'", ent))
               .collect(Collectors.joining(", ")),
-            projectId.getFullResourceName(),
             requestedRoleBindingDuration.toMinutes()))
         .addLabels(le -> addLabels(le, activationRequest))
         .write();
@@ -143,12 +142,11 @@ public class RequestAndSelfApproveAction extends AbstractActivationAction {
         .newErrorEntry(
           LogEvents.API_ACTIVATE_ROLE,
           String.format(
-            "User %s failed to activate roles %s on '%s' for themselves for %d minutes: %s",
+            "User %s failed to activate %s for themselves for %d minutes: %s",
             iapPrincipal.email(),
             activationRequest.entitlements().stream()
-              .map(ent -> String.format("'%s'", ent.role()))
+              .map(ent -> String.format("'%s'", ent))
               .collect(Collectors.joining(", ")),
-            projectId.getFullResourceName(),
             requestedRoleBindingDuration.toMinutes(),
             Exceptions.getFullMessage(e)))
         .addLabels(le -> addLabels(le, projectId))

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/TestActivationRequest.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/TestActivationRequest.java
@@ -84,7 +84,7 @@ public class TestActivationRequest {
       Duration.ofMinutes(5));
 
     assertEquals(
-      "[sample-1] entitlements=sample:1, startTime=1970-01-01T00:00:00Z, " +
+      "[sample-1] entitlements=1, startTime=1970-01-01T00:00:00Z, " +
         "duration=PT5M, justification=some justification",
       request.toString());
   }

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestProjectRole.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/catalog/project/TestProjectRole.java
@@ -46,10 +46,10 @@ public class TestProjectRole {
   @Test
   public void toStringReturnsResourceAndRole() {
     assertEquals(
-      "iam:project-1:role/sample",
+      "[iam] role/sample on project-1",
       new ProjectRole(SAMPLE_PROJECT, "role/sample").toString());
     assertEquals(
-      "iam:project-1:role/sample:cmVzb3VyY2UubmFtZT09J2Zvbyc=",
+      "[iam] role/sample on project-1 (condition: resource.name=='foo')",
       new ProjectRole(SAMPLE_PROJECT, "role/sample", "resource.name=='foo'").toString());
   }
 


### PR DESCRIPTION
* Change ProjectRole.toString return friendly string representation
* Use ProjectRole.toString in log statements to ensure that resource conditions are included in the log message