### PR TITLE
Add 'IAP_VERIFY_AUDIENCE' option to en/disable audience check

### DIFF
--- a/doc/site/sources/docs/configuration-options.md
+++ b/doc/site/sources/docs/configuration-options.md
@@ -384,6 +384,40 @@ The following table lists all available configuration options.
   </tr>
   <tr>
     <td>
+        <code>IAP_BACKEND_SERVICE_ID</code>
+    </td>
+    <td>
+        <p>
+            ID of the load balancer backend used by IAP. The ID is used 
+            for <a href="https://cloud.google.com/iap/docs/signed-headers-howto#verifying_the_jwt_payload">
+            verifying the audience</a> of IAP assertions
+        </p>
+    </td>
+    <td>Required on Cloud Run unless <code>IAP_VERIFY_AUDIENCE=false</code></td>
+    <td></td>
+    <td>1.3</td>
+  </tr>
+  <tr>
+    <td>
+        <code>IAP_VERIFY_AUDIENCE</code>
+    </td>
+    <td>
+        <p>
+            When set to <code>true</code>, the application
+            <a href="https://cloud.google.com/iap/docs/signed-headers-howto#verifying_the_jwt_payload">
+            verifies the audience</a> of IAP assertions, in addition to verifying their authenticity.</a>.
+        </p>
+        <p>
+            When set to <code>false</code>, the application
+            verifies the authenticity of IAP assertions, but does not verify their audience.
+        </p>
+    </td>
+    <td>Optional</td>
+    <td>true</td>
+    <td>1.8.1</td>
+  </tr>
+  <tr>
+    <td>
         <code>BACKEND_CONNECT_TIMEOUT</code>
     </td>
     <td>

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeConfiguration.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RuntimeConfiguration.java
@@ -100,6 +100,7 @@ class RuntimeConfiguration {
     // Backend service id (Cloud Run only).
     //
     this.backendServiceId = new StringSetting(List.of("IAP_BACKEND_SERVICE_ID"), null);
+    this.verifyIapAudience = new BooleanSetting(List.of("IAP_VERIFY_AUDIENCE"), true);
 
     //
     // Notification settings.
@@ -248,6 +249,11 @@ class RuntimeConfiguration {
    * Backend Service Id for token validation
    */
   public final @NotNull StringSetting backendServiceId;
+
+  /**
+   * Check audience of IAP assertions.
+   */
+  public final @NotNull BooleanSetting verifyIapAudience;
 
   /**
    * Minimum number of reviewers foa an activation request.

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestIapRequestFilter.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestIapRequestFilter.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -90,6 +91,56 @@ public class TestIapRequestFilter {
     when(request.getHeaderString(anyString())).thenReturn(randomJwt);
 
     assertThrows(ForbiddenException.class, () -> filter.filter(request));
+  }
+
+  @Test
+  public void whenSkippingIAPVerificationWithIncorrectProject_ThenFilterThrowsForbiddenException() {
+    RuntimeEnvironment environment = Mockito.mock(RuntimeEnvironment.class);
+    when(environment.getProjectId()).thenReturn("123");
+    when(environment.getProjectNumber()).thenReturn("123");
+    when(environment.isRunningOnAppEngine()).thenReturn(false);
+    when(environment.isRunningOnCloudRun()).thenReturn(true);
+    when(environment.isDebugModeEnabled()).thenReturn(false);
+    when(environment.getBackendServiceId()).thenReturn("SKIP_IAP_VERIFICATION");
+
+    IapRequestFilter filter = new IapRequestFilter();
+    filter.runtimeEnvironment = environment;
+    filter.log = new LogAdapter();
+
+    // "aud": "/projects/not_123/global/backendServices/"
+    String wrongProjectJwt = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhdWQiOiIvcHJvamVjdHMvbm90XzEyMy9nbG9iYWwvYmFja2VuZFNlcnZpY2VzLyJ9.";
+
+    ContainerRequestContext request = Mockito.mock(ContainerRequestContext.class);
+    when(request.getHeaderString(anyString())).thenReturn(wrongProjectJwt);
+
+    ForbiddenException thrown = assertThrows(ForbiddenException.class, () -> filter.filter(request));
+    assertEquals("Expected audience prefix mismatch.", thrown.getMessage());
+  }
+
+  @Test
+  public void whenSkippingIAPVerificationWithCorrectProject_ThenFilterThrowsForbiddenException() {
+    RuntimeEnvironment environment = Mockito.mock(RuntimeEnvironment.class);
+    when(environment.getProjectId()).thenReturn("123");
+    when(environment.getProjectNumber()).thenReturn("123");
+    when(environment.isRunningOnAppEngine()).thenReturn(false);
+    when(environment.isRunningOnCloudRun()).thenReturn(true);
+    when(environment.isDebugModeEnabled()).thenReturn(false);
+    when(environment.getBackendServiceId()).thenReturn("SKIP_IAP_VERIFICATION");
+
+    IapRequestFilter filter = new IapRequestFilter();
+    filter.runtimeEnvironment = environment;
+    filter.log = new LogAdapter();
+
+    // "aud": "/projects/123/global/backendServices/some_unknown_thing"
+    String rightProjectJwt = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhdWQiOiIvcHJvamVjdHMvMTIzL2dsb2JhbC9iYWNrZW5kU2VydmljZXMvc29tZV91bmtub3duX3RoaW5nIn0.";
+
+    ContainerRequestContext request = Mockito.mock(ContainerRequestContext.class);
+    when(request.getHeaderString(anyString())).thenReturn(rightProjectJwt);
+
+    // This should fail because the JWT is unsigned, not because of the audience
+    // prefix.
+    ForbiddenException thrown = assertThrows(ForbiddenException.class, () -> filter.filter(request));
+    assertNotEquals("Expected audience prefix mismatch.", thrown.getMessage());
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Add configuration option `IAP_VERIFY_AUDIENCE`:

* The option defaults to `true`, meaning that the audience of IAP assertions is verified.
* When set to `false`, the audience of IAP assertions is not verified and the option `IAP_BACKEND_SERVICE_ID` is ignored. 

NB. The assertion's signature is always verified, regardless of `IAP_VERIFY_AUDIENCE`.