### PR TITLE
b/357944663 Remove requirement for groups to have an ACL

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocument.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocument.java
@@ -240,7 +240,6 @@ public class PolicyDocument {
       ENVIRONMENT_INVALID,
       SYSTEM_INVALID,
       GROUP_INVALID,
-      GROUP_MISSING_ACL,
       ACL_INVALID_PRINCIPAL,
       ACL_INVALID_PERMISSION,
       CONSTRAINT_INVALID_VARIABLE_DECLARATION,
@@ -591,12 +590,6 @@ public class PolicyDocument {
     @NotNull Optional<JitGroupPolicy> toPolicy(@NotNull IssueCollection issues) {
       issues.setScope(Coalesce.nonEmpty(this.name, "Unnamed group"));
 
-      if (this.acl == null) {
-        issues.error(
-          Issue.Code.GROUP_MISSING_ACL,
-          "The group lacks an access control list");
-      }
-
       var aces = Coalesce
         .emptyIfNull(this.acl)
         .stream()
@@ -615,7 +608,6 @@ public class PolicyDocument {
 
       return NullaryOptional
         .ifTrue(
-          this.acl != null &&
           constraints.isPresent() &&
           aces.stream().allMatch(Optional::isPresent) &&
           roleBindings.stream().allMatch(Optional::isPresent))

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyDocument.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyDocument.java
@@ -613,10 +613,8 @@ public class TestPolicyDocument {
       var issues = new PolicyDocument.IssueCollection();
       var policy = element.toPolicy(issues);
 
-      assertFalse(policy.isPresent());
-      assertEquals(
-        PolicyDocument.Issue.Code.GROUP_MISSING_ACL,
-        issues.issues().get(0).code());
+      assertTrue(policy.isPresent());
+      assertTrue(policy.get().accessControlList().get().entries().isEmpty());
     }
 
     @Test
@@ -627,7 +625,7 @@ public class TestPolicyDocument {
 
       assertTrue(policy.isPresent());
       assertTrue(policy.get().accessControlList().isPresent());
-      assertEquals(0, policy.get().accessControlList().get().entries().size());
+      assertTrue(policy.get().accessControlList().get().entries().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
It's okay for groups to use an inherited ACL.