### PR TITLE
b/357952862 Rename to class:iapUsers

### DIFF
--- a/doc/site/sources/docs/policy-reference.md
+++ b/doc/site/sources/docs/policy-reference.md
@@ -72,13 +72,13 @@ environment:
 
     ```yaml
     access:
-    - principal: "class:authenticatedUsers"
+    - principal: "class:iapUsers"
       allow: "VIEW"
     ```
 
     !!!note
-        Access to the application is guarded by Identity-Aware Proxy. The principal `class:authenticatedUsers`
-        therefore only includes users that Identity-Aware Proxy allows to access the application.
+        Access to the application is guarded by Identity-Aware Proxy (IAP). The principal `class:iapUsers`
+        therefore only includes users that have been authorized by IAP to access the application.
 
 `constraints` **Optional**
 
@@ -206,7 +206,7 @@ An Access Control List (ACL) contains one or more access control entries (ACE).
 
 ```yaml hl_lines="2-9"
 access:
-- principal: "class:authenticatedUsers"         # Everybody can view
+- principal: "class:iapUsers"         # Everybody can view
   allow: "VIEW"
 - principal: "group:devops-staff@example.com"   # Devops staff can request to join
   allow: "JOIN"
@@ -226,7 +226,7 @@ Each ACE can have the following attributes:
     |------------------|------------------|------------------|
     | `user:USER_EMAIL` | User with primary email address `USER_EMAIL`. | `user:bob@example.com` |
     | `group:GROUP_EMAIL` | Includes all _direct_ members of the Cloud Identity/Workspace group `GROUP_EMAIL`.| `group:devops-staff@example.com`|
-    | `class:authenticatedUsers` |  Includes all authenticated users that can access the application ||
+    | `class:iapUsers` |  Includes all users that have been authorized by IAP to access the application ||
 
     **Remarks**:
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/SubjectResolver.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/SubjectResolver.java
@@ -215,7 +215,7 @@ public class SubjectResolver {
     var jitGroupPrincipals = resolveMemberships(user, jitGroupMemberships);
 
     var allPrincipals = new HashSet<Principal>();
-    allPrincipals.add(new Principal(UserClassId.AUTHENTICATED_USERS));
+    allPrincipals.add(new Principal(UserClassId.IAP_USERS));
     allPrincipals.add(new Principal(user));
     allPrincipals.addAll(otherGroupPrincipals);
     allPrincipals.addAll(jitGroupPrincipals);

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/UserClassId.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/UserClassId.java
@@ -36,9 +36,10 @@ public class UserClassId implements PrincipalId, Comparable<UserClassId> {
   private final @NotNull String value;
 
   /**
-   * Principal identifier that identifies all users.
+   * Principal identifier that identifies all users that
+   * have been authorized by IAP.
    */
-  public static final @NotNull UserClassId AUTHENTICATED_USERS = new UserClassId("authenticatedUsers");
+  public static final @NotNull UserClassId IAP_USERS = new UserClassId("iapUsers");
 
   private UserClassId(@NotNull String value) {
     this.value = value;
@@ -54,8 +55,8 @@ public class UserClassId implements PrincipalId, Comparable<UserClassId> {
 
     s = s.trim();
 
-    if (s.equalsIgnoreCase(AUTHENTICATED_USERS.toString())) {
-      return Optional.of(AUTHENTICATED_USERS);
+    if (s.equalsIgnoreCase(IAP_USERS.toString())) {
+      return Optional.of(IAP_USERS);
     }
     else {
       return Optional.empty();

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/legacy/LegacyPolicy.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/legacy/LegacyPolicy.java
@@ -136,7 +136,7 @@ public class LegacyPolicy extends EnvironmentPolicy {
             //
             // Allow all users to VIEW.
             //
-            Stream.of(new AccessControlList.AllowedEntry(UserClassId.AUTHENTICATED_USERS, PolicyPermission.VIEW.toMask())))
+            Stream.of(new AccessControlList.AllowedEntry(UserClassId.IAP_USERS, PolicyPermission.VIEW.toMask())))
           .toList()
       ),
       Map.of(

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/EnvironmentPolicy.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/EnvironmentPolicy.java
@@ -42,7 +42,7 @@ public class EnvironmentPolicy extends AbstractPolicy {
    * Default ACL for environments.
    */
   static final AccessControlList DEFAULT_ACCESS_CONTROL_LIST = new AccessControlList(
-    List.of(new AccessControlList.AllowedEntry(UserClassId.AUTHENTICATED_USERS, PolicyPermission.VIEW.toMask())));
+    List.of(new AccessControlList.AllowedEntry(UserClassId.IAP_USERS, PolicyPermission.VIEW.toMask())));
 
   private final @NotNull Map<String, SystemPolicy> systems = new TreeMap<>();
 

--- a/sources/src/main/resources/oobe/policy.yaml
+++ b/sources/src/main/resources/oobe/policy.yaml
@@ -5,7 +5,7 @@ environment:
     This is an example environment that demonstrates some of the application's features. The
     environment is shown because you haven't configured any environments yet.
   access:
-    - principal: "class:authenticatedUsers"
+    - principal: "class:iapUsers"
       allow: "VIEW, EXPORT, RECONCILE"
   constraints:
     join:
@@ -32,7 +32,7 @@ environment:
           description: |
             Administer Shared VPC networks and firewalls
           access:
-            - principal: "class:authenticatedUsers"
+            - principal: "class:iapUsers"
               allow: "VIEW, JOIN"
           privileges:
             iam:
@@ -50,7 +50,7 @@ environment:
           description: |
             Manage Identity-Aware Proxy and other security settings
           access:
-            - principal: "class:authenticatedUsers"
+            - principal: "class:iapUsers"
               allow: "VIEW"
           privileges:
             iam:
@@ -72,7 +72,7 @@ environment:
           description: |
             View audit logs
           access:
-            - principal: "class:authenticatedUsers"
+            - principal: "class:iapUsers"
               allow: "VIEW, JOIN, APPROVE_SELF"
           privileges:
             iam:

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/Subjects.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/Subjects.java
@@ -38,7 +38,7 @@ public class Subjects {
   ) {
     var defaultPrincipals = Stream.of(
       new Principal(user),
-      new Principal(UserClassId.AUTHENTICATED_USERS));
+      new Principal(UserClassId.IAP_USERS));
 
     var subject = Mockito.mock(Subject.class);
     when(subject.user()).thenReturn(user);

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestSubjectResolver.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestSubjectResolver.java
@@ -184,6 +184,6 @@ public class TestSubjectResolver {
     assertTrue(principals.contains(SAMPLE_USER), "user principal");
     assertTrue(principals.contains(SAMPLE_GROUP), "other group");
     assertTrue(principals.contains(SAMPLE_JITGROUP), "JIT group");
-    assertTrue(principals.contains(UserClassId.AUTHENTICATED_USERS), "All");
+    assertTrue(principals.contains(UserClassId.IAP_USERS), "All");
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestUserClassId.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestUserClassId.java
@@ -34,7 +34,7 @@ public class TestUserClassId {
 
   @Test
   public void toString_returnsPrefixedValue() {
-    assertEquals("class:authenticatedUsers", UserClassId.AUTHENTICATED_USERS.toString());
+    assertEquals("class:iapUsers", UserClassId.IAP_USERS.toString());
   }
 
   // -------------------------------------------------------------------------
@@ -43,8 +43,8 @@ public class TestUserClassId {
 
   @Test
   public void equals_whenObjectAreEquivalent() {
-    UserClassId id1 = UserClassId.AUTHENTICATED_USERS;
-    UserClassId id2 = UserClassId.AUTHENTICATED_USERS;
+    UserClassId id1 = UserClassId.IAP_USERS;
+    UserClassId id2 = UserClassId.IAP_USERS;
 
     assertTrue(id1.equals(id2));
     assertEquals(id1.hashCode(), id2.hashCode());
@@ -53,13 +53,13 @@ public class TestUserClassId {
 
   @Test
   public void equals_whenObjectIsNull() {
-    assertFalse(UserClassId.AUTHENTICATED_USERS.equals(null));
+    assertFalse(UserClassId.IAP_USERS.equals(null));
   }
 
   @Test
   public void equals_whenObjectIsDifferentType() {
-    assertFalse(UserClassId.AUTHENTICATED_USERS.equals(""));
-    assertFalse(UserClassId.AUTHENTICATED_USERS.equals(new UserId("user@example.com")));
+    assertFalse(UserClassId.IAP_USERS.equals(""));
+    assertFalse(UserClassId.IAP_USERS.equals(new UserId("user@example.com")));
   }
 
   // -------------------------------------------------------------------------
@@ -68,12 +68,12 @@ public class TestUserClassId {
 
   @Test
   public void value() {
-    assertEquals("authenticatedUsers", UserClassId.AUTHENTICATED_USERS.value());
+    assertEquals("iapUsers", UserClassId.IAP_USERS.value());
   }
 
   @Test
   public void iamPrincipalId() {
-    assertFalse(((Object)UserClassId.AUTHENTICATED_USERS) instanceof IamPrincipalId);
+    assertFalse(((Object)UserClassId.IAP_USERS) instanceof IamPrincipalId);
   }
 
   // -------------------------------------------------------------------------
@@ -85,7 +85,7 @@ public class TestUserClassId {
     "",
     "class",
     "class:",
-    " class:  authenticatedUsers",
+    " class:  iapUsers",
     "class"
   })
   public void parse_whenInvalid(String s) {
@@ -95,10 +95,10 @@ public class TestUserClassId {
 
   @ParameterizedTest
   @ValueSource(strings = {
-    " class:authenticatedUsers",
-    "class:AUTHENTICATEDUSERS  "
+    " class:iapUsers",
+    "class:IAPUSERS  "
   })
   public void parse(String s) {
-    assertEquals(UserClassId.AUTHENTICATED_USERS, UserClassId.parse(s).get());
+    assertEquals(UserClassId.IAP_USERS, UserClassId.parse(s).get());
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/legacy/TestLegacyPolicy.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/legacy/TestLegacyPolicy.java
@@ -61,7 +61,7 @@ public class TestLegacyPolicy {
 
     var aces = List.copyOf(policy.accessControlList().get().entries());
     assertEquals(1, aces.size());
-    assertEquals(UserClassId.AUTHENTICATED_USERS, aces.get(0).principal);
+    assertEquals(UserClassId.IAP_USERS, aces.get(0).principal);
     assertEquals(PolicyPermission.VIEW.toMask(), aces.get(0).accessRights);
   }
 
@@ -96,7 +96,7 @@ public class TestLegacyPolicy {
     assertEquals(new UserId("admin-1@example.com"), aces.get(0).principal);
     assertEquals(PolicyPermission.EXPORT.toMask(), aces.get(0).accessRights);
 
-    assertEquals(UserClassId.AUTHENTICATED_USERS, aces.get(1).principal);
+    assertEquals(UserClassId.IAP_USERS, aces.get(1).principal);
     assertEquals(PolicyPermission.VIEW.toMask(), aces.get(1).accessRights);
   }
 
@@ -131,7 +131,7 @@ public class TestLegacyPolicy {
     assertEquals(new UserId("admin-1@example.com"), aces.get(1).principal);
     assertEquals(PolicyPermission.RECONCILE.toMask(), aces.get(1).accessRights);
 
-    assertEquals(UserClassId.AUTHENTICATED_USERS, aces.get(2).principal);
+    assertEquals(UserClassId.IAP_USERS, aces.get(2).principal);
     assertEquals(PolicyPermission.VIEW.toMask(), aces.get(2).accessRights);
   }
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyDocument.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyDocument.java
@@ -62,7 +62,7 @@ public class TestPolicyDocument {
         "  name: \"env\"\n" +
         "  description: \"\"\n" +
         "  access:\n" +
-        "  - principal: \"class:authenticatedUsers\"\n" +
+        "  - principal: \"class:iapUsers\"\n" +
         "    allow: \"VIEW\"\n" +
         "  systems: []\n",
       new PolicyDocument(policy).toString());
@@ -303,7 +303,7 @@ public class TestPolicyDocument {
 
       var aces = List.copyOf(policy.get().accessControlList().get().entries());
       assertEquals(1, aces.size());
-      assertEquals(UserClassId.AUTHENTICATED_USERS, aces.get(0).principal);
+      assertEquals(UserClassId.IAP_USERS, aces.get(0).principal);
       assertEquals(PolicyPermission.VIEW.toMask(), aces.get(0).accessRights);
     }
 


### PR DESCRIPTION
Rename principal ID to class:iapUsers to make it clearer that it only captures users that have been authorized by IAP.