### PR TITLE
b/357950721 Add ALL permission

### DIFF
--- a/doc/site/sources/docs/policy-reference.md
+++ b/doc/site/sources/docs/policy-reference.md
@@ -246,12 +246,13 @@ Each ACE can have the following attributes:
     | `APPROVE_OTHERS` | Approve other's requests to join the group.                                          | Group                      |
     | `EXPORT`         | View or export the policy in the user interface.                                     | Environment                |
     | `RECONCILE`      | Reconcile the policy.                                                                | Environment                |
+    | `ALL`            | Full access, includes all other permissions.                                         | Environment, system, group |
     
     **Remarks**:
     
     +   `APPROVE_OTHERS` does _not_ allow users to approve their own join requests. Only the `APPROVE_SELF` permission
         allows users to join without approval.
-    +   `JOIN`, `APPROVE_SELF`, `APPROVE_OTHERS`, `EXPORT`, `RECONCILE` include the  `VIEW` permission.
+    +   The  `VIEW` permission is implied by all other permissions.
 
 ## Constraint
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyDocument.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyDocument.java
@@ -757,7 +757,7 @@ public class TestPolicyDocument {
       var element = PolicyDocument.AccessControlEntryElement.fromPolicy(ace);
 
       assertEquals("user:" + SAMPLE_USER.email, element.principal());
-      assertEquals("VIEW, JOIN, APPROVE_OTHERS, APPROVE_SELF", element.allowedPermissions());
+      assertEquals("JOIN, APPROVE_OTHERS, APPROVE_SELF", element.allowedPermissions());
       assertNull(element.deniedPermissions());
     }
 
@@ -767,7 +767,7 @@ public class TestPolicyDocument {
       var element = PolicyDocument.AccessControlEntryElement.fromPolicy(ace);
 
       assertEquals("user:" + SAMPLE_USER.email, element.principal());
-      assertEquals("VIEW, JOIN, APPROVE_OTHERS", element.deniedPermissions());
+      assertEquals("JOIN, APPROVE_OTHERS", element.deniedPermissions());
       assertNull(element.allowedPermissions());
     }
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyPermission.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyPermission.java
@@ -73,15 +73,38 @@ public class TestPolicyPermission {
   @Test
   public void fromMask_whenSingleValue() {
     assertEquals(
-      EnumSet.of(PolicyPermission.VIEW, PolicyPermission.JOIN),
+      EnumSet.of(PolicyPermission.VIEW),
+      PolicyPermission.fromMask(1));
+    assertEquals(
+      EnumSet.of(PolicyPermission.JOIN),
       PolicyPermission.fromMask(3));
+    assertEquals(
+      EnumSet.of(PolicyPermission.APPROVE_OTHERS),
+      PolicyPermission.fromMask(5));
+    assertEquals(
+      EnumSet.of(PolicyPermission.APPROVE_SELF),
+      PolicyPermission.fromMask(9));
   }
 
   @Test
   public void fromMask_whenCombinedValue() {
     assertEquals(
-      EnumSet.of(PolicyPermission.VIEW, PolicyPermission.JOIN, PolicyPermission.APPROVE_SELF),
+      EnumSet.of(PolicyPermission.JOIN, PolicyPermission.APPROVE_SELF),
       PolicyPermission.fromMask(11));
+    assertEquals(
+      EnumSet.of(PolicyPermission.APPROVE_OTHERS, PolicyPermission.APPROVE_SELF),
+      PolicyPermission.fromMask(13));
+    assertEquals(
+      EnumSet.of(
+        PolicyPermission.JOIN,
+        PolicyPermission.APPROVE_SELF,
+        PolicyPermission.APPROVE_OTHERS,
+        PolicyPermission.EXPORT,
+        PolicyPermission.RECONCILE),
+      PolicyPermission.fromMask(0xFF));
+    assertEquals(
+      EnumSet.of(PolicyPermission.ALL),
+      PolicyPermission.fromMask(0x7FFFFFFF));
   }
 
   //---------------------------------------------------------------------------


### PR DESCRIPTION
- Add `ALL` permission that implies all other permission
- When converting access masks to EnumSets, canonicalize the result by ignoring implied permissions