### PR TITLE
b/360194758 Remove recipients-check

### DIFF
--- a/sources/.idea/google-java-format.xml
+++ b/sources/.idea/google-java-format.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoogleJavaFormatSettings">
+    <option name="enabled" value="true" />
+  </component>
+</project>

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/JitGroupContext.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/JitGroupContext.java
@@ -116,10 +116,16 @@ public class JitGroupContext {
     Preconditions.checkArgument(
       proposal.expiry().isAfter(Instant.now()),
       "Proposal must not be expired");
-    Preconditions.checkArgument(
-      proposal.user().equals(this.subject.user()) ||
-      proposal.recipients().contains(JitGroupContext.this.subject.user()),
-      "Current user must be among recipients");
+
+    //
+    // NB. We're not checking if the user is among the recipients
+    // of the proposal. That's for 2 reasons:
+    //
+    // (1) The current user might be part of a group. To verify if the
+    //     user is among the recipients, we'd have to expand groups.
+    // (2) What matters is if the user is allowed to approve based on
+    //     the ACL, not the list of recipients.
+    //
 
     //
     // Recreate the list of inputs that the user provided initially.


### PR DESCRIPTION
Remove check as it's redundant to the ACL check, and because it doesn't consisider the case where a user is part of a group, and the list of recipients only contains that group.