### PR TITLE
b/517810218 Pass cookies when fetching manifest

### DIFF
--- a/sources/src/main/resources/META-INF/resources/index.html
+++ b/sources/src/main/resources/META-INF/resources/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <meta name="referrer" content="no-referrer" />
     <meta name="theme-color" content="#006CBE" />
-    <link rel="manifest" href="manifest.json" />
+    <link rel="manifest" href="manifest.json" crossorigin="use-credentials"/>
 
     <title>JIT Groups</title>
 


### PR DESCRIPTION
Ensure that the manifest can be fetched when the app is deployed behind IAP.